### PR TITLE
Feature/cli improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ Fast, reproducible access to **precalculated model outputs** from the **Ersilia 
 
 [Installation](#installation) ·
 [CLI](#cli) ·
-[Python API](#python-api) ·
 [Configuration](#configuration) ·
-[Docs](#docs) ·
-[Contributing](#contributing)
+[Docs](#docs)
 
 </div>
 
@@ -109,7 +107,7 @@ This checks connectivity for local and cloud (if configured) and prints a result
 
 ## CLI
 
-### Managing configuration
+### Configuration
 
 ```bash
 isaura configure                     # show current configuration
@@ -119,7 +117,7 @@ isaura configure --show-secrets      # show all credential values unmasked
 isaura configure --test-credentials  # test local and cloud connectivity
 ```
 
-### Managing local services
+### Local services
 
 ```bash
 isaura engine           # show status of Docker and MinIO
@@ -127,97 +125,106 @@ isaura engine --start   # start local MinIO
 isaura engine --stop    # stop local MinIO
 ```
 
-### Common data commands
+### Projects
 
-#### Write (store outputs)
-
-```bash
-isaura write -i data/ersilia_output.csv -m eos8a4x -v v2 -pn myproject --access public
-```
-
-#### Read (retrieve outputs)
+A **project** is a named MinIO bucket used as a staging area before data reaches the canonical `isaura-public` or `isaura-private` buckets.
 
 ```bash
-isaura read -i data/inputs.csv -m eos8a4x -v v2 -pn myproject -o data/outputs.csv
+isaura info                  # list local projects with access type and creation date
+isaura info --remote         # list remote projects
+
+isaura create -pn myproject --access public   # create a new local project
+isaura destroy -pn myproject                  # destroy an entire project
+isaura destroy -pn myproject -m eos8a4x -v v1 # destroy a specific model version
 ```
 
-#### Copy artifacts to a local directory
+> `isaura-public` and `isaura-private` are reserved — they cannot be fully destroyed, but individual model versions inside them can be removed with `--model-id` and `--version`.
+
+### Writing outputs
+
+Store model outputs in a project bucket:
 
 ```bash
-isaura copy -m eos8a4x -v v1 -pn myproject -o ~/Documents/isaura-backup/
+isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject
 ```
 
-#### Inspect available entries
+The model ID in `--model-id` is validated against the filename — if you accidentally pass a file from a different model, isaura will warn you before writing anything.
+
+### Reading outputs
+
+Retrieve stored outputs for a set of inputs:
 
 ```bash
-isaura inspect -m eos8a4x -v v1 -o reports/available.csv
+# explicit version
+isaura read -i data/inputs.csv -m eos8a4x -v v1 -pn myproject -o data/outputs.csv
+
+# omit --version to automatically use the latest stored version
+isaura read -i data/inputs.csv -m eos8a4x -pn myproject -o data/outputs.csv
 ```
 
-#### Upload to cloud store
+`--project-name` is required. `--output` is optional — without it results are printed but not saved.
 
-The cloud only hosts two canonical buckets: `isaura-public` and `isaura-private`. If your local work uses a custom project name, copy or move it into the appropriate canonical bucket first, then push.
+### Inspecting what is stored
 
-**Step 1 — write outputs to your local project:**
+Check which molecules from an input file are already cached:
 
 ```bash
-isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject --access public
+isaura inspect --model_id eos8a4x -v v1 --access public -i data/inputs.csv -o reports/available.csv
 ```
 
-**Step 2 — copy (or move) into the canonical bucket:**
+Browse all models in a project:
 
 ```bash
-# copy (keeps data in myproject as well)
-isaura copy -m eos8a4x -v v1 -pn myproject
-
-# or move (removes data from myproject after copying)
-isaura move -m eos8a4x -v v1 -pn myproject
+isaura catalog -pn myproject           # local
+isaura catalog -pn isaura-public -r    # remote
 ```
+
+### Publishing to the cloud
+
+The cloud hosts two canonical buckets: `isaura-public` and `isaura-private`. Write to a local project first, persist it into the canonical bucket, then push to cloud.
+
+**Step 1 — write to your local project:**
+
+```bash
+isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject
+```
+
+**Step 2 — persist into the canonical bucket:**
+
+```bash
+isaura persist -m eos8a4x -v v1 -pn myproject
+```
+
+This routes molecules tagged `public` → `isaura-public` and `private` → `isaura-private` based on the project's access setting.
 
 **Step 3 — push to cloud:**
 
 ```bash
 isaura push -m eos8a4x -v v1 -pn isaura-public
-# or for private data:
-isaura push -m eos8a4x -v v1 -pn isaura-private
 ```
 
 > Cloud credentials must be configured first with `isaura configure --remote`.
 
----
+### Pulling from the cloud
 
-## Python API
+Download precalculations from the remote store into your local MinIO:
 
-```python
-from isaura.manage import IsauraWriter, IsauraReader
+```bash
+# explicit version
+isaura pull -i data/inputs.csv -m eos8a4x -v v1 -pn isaura-public
+
+# omit --version to automatically pull the latest stored version
+isaura pull -i data/inputs.csv -m eos8a4x -pn isaura-public
 ```
 
-Write a precalculation:
+### Storage statistics
 
-```python
-writer = IsauraWriter(
-    input_csv="data/input.csv",
-    model_id="eos8a4x",
-    model_version="v1",
-    bucket="my-project",
-    access="public",
-)
-writer.write()
+Generate a JSON inventory of all models in a bucket:
+
+```bash
+isaura stats -pn isaura-public -o ./reports
+isaura stats -pn myproject --remote -o ./reports
 ```
-
-Read stored results:
-
-```python
-reader = IsauraReader(
-    model_id="eos8a4x",
-    model_version="v1",
-    bucket="my-project",
-    input_csv="data/query.csv",
-    approximate=False,
-)
-reader.read(output_csv="results.csv")
-```
-
-More examples: **[API and CLI usage →](docs/API_AND_CLI_USAGE.md)**
 
 ---
 
@@ -242,18 +249,6 @@ See the full list of available variables: **[CONFIGURATION →](docs/CONFIGURATI
 * 🧰 **CLI and API reference**: [here](docs/API_AND_CLI_USAGE.md)
 * 🧪 **Benchmark**: [here](docs/BENCHMARK.md)
 * 🩹 **Troubleshooting / recovery**: [here](docs/TROUBLESHOOTING.md)
-
----
-
-## Contributing
-
-PRs are welcome. Please run format + lint before pushing:
-
-```bash
-uv run ruff format .
-```
-
-If you're changing CLI behavior, please update **[here](docs/API_AND_CLI_USAGE.md)**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="./isaura/assets/isaura_v2.png" height="160" alt="Isaura logo" />
 
-### Ersilia’s Precalculation Store
+### Ersilia's Precalculation Store
 
 Fast, reproducible access to **precalculated model outputs** from the **Ersilia Model Hub** — with a CLI and Python API built for batch workflows.
 
@@ -28,29 +28,14 @@ Fast, reproducible access to **precalculated model outputs** from the **Ersilia 
 ---
 
 ## Why Isaura?
-Isaura is Ersilia’s precalculation store: it **persistently stores model outputs** so researchers can retrieve results instantly instead of repeatedly runningtime-consuming inference. This delivers a major research speed-up—especially in low-resource settings where compute, bandwidth, or infrastructure are limited—by turning repeated calculations into reusable shared artifacts. To support equitable access, Ersilia also provides **free access to public precalculations**, making high-value model outputs available even when local compute isn’t.
+Isaura is Ersilia's precalculation store: it **persistently stores model outputs** so researchers can retrieve results instantly instead of repeatedly running time-consuming inference. This delivers a major research speed-up — especially in low-resource settings where compute, bandwidth, or infrastructure are limited — by turning repeated calculations into reusable shared artifacts. To support equitable access, Ersilia also provides **free access to public precalculations**, making high-value model outputs available even when local compute isn't.
 
 Isaura provides a structured store for model results so you can:
 
 - ⚡ **Skip recomputation** by reusing precalculated outputs
 - 🧱 Keep artifacts **versioned and organized** (model → version → bucket/project)
-- 📦 Store and retrieve results via **S3-compatible object storage (MinIO)**  
-- 🔎 Enable **fast retrieval** using its fast engine developed on top of duckdb and for ANN uses vector search / indexing components (Milvus + NN service)
-
----
-## Architecture (high level)
-
-* 📝 **Write:** `CLI / Python API → MinIO`
-  Precomputed outputs are stored as chunked artifacts (e.g., Parquet) under `model_id/version`, and Isaura updates lightweight registries (index/metadata/bloom) for deduplication and fast lookup.
-
-* 📥 **Read(exact):** `CLI / Python API → DuckDB query on MinIO → results`
-  Inputs are matched against the index, then the corresponding rows are fetched directly from the stored chunks.
-
-* ⚡ **Read (approx / ANN, optional):** `CLI / Python API → NN service (+ Milvus) → nearest match → exact fetch from MinIO`
-  For unseen inputs, the NN service finds the closest indexed compound(s); Isaura then retrieves the corresponding stored result from MinIO.
-
-
-See the deep dive: **[How it works →](docs/HOW_IT_WORKS.md)**
+- 📦 Store and retrieve results via **S3-compatible object storage (MinIO)**
+- 🔎 Enable **fast retrieval** using its engine built on top of DuckDB
 
 ---
 
@@ -58,94 +43,91 @@ See the deep dive: **[How it works →](docs/HOW_IT_WORKS.md)**
 
 ### Prerequisites
 
-Before installing Isaura, make sure you have the following:
-
 - **Python 3.10+** — [download here](https://www.python.org/downloads/)
-- **Git** — used to download the project ([download here](https://git-scm.com/downloads))
-- **Docker** — required to run local services like MinIO. [Download Docker Desktop](https://www.docker.com/products/docker-desktop/)
-- **Docker Compose** — use docker-compose v2
-- **Write permissions**  — make sure you have write permissions in your filesystem
+- **Git** — [download here](https://git-scm.com/downloads)
+- **Docker Desktop** — [download here](https://www.docker.com/products/docker-desktop/) — must be open before starting local services
 
 ---
 
-### Option A: Standard install *(recommended for most users)*
-
-This is the simplest path. Open a terminal and run the following commands one by one.
-
-**1. Clone the repository** — this downloads the project to your computer:
+### Step 1 — Clone and install
 
 ```bash
 git clone https://github.com/ersilia-os/isaura.git
-```
-
-**2. Navigate into the project folder:**
-
-```bash
 cd isaura
-```
-
-**3a. Install Isaura through pip:**
-
-```bash
-conda activate <your_env>
 pip install -e .
 ```
 
-The `-e` flag installs it in "editable" mode, meaning any changes you make to the source code are reflected immediately without reinstalling.
+> **Using uv?** Run `uv sync` instead and activate the environment with `source .venv/bin/activate`.
+
+A local configuration file is created automatically at `~/.isaura/.env` with sensible defaults the first time you run any `isaura` command.
 
 ---
 
-### Option B: Install with uv *(recommended for developers)*
-[uv](https://docs.astral.sh/uv/) is a faster alternative to pip. If you don't have it yet, [install it first](https://docs.astral.sh/uv/getting-started/installation/).
+### Step 2 — Start local services
 
-```bash
-git clone https://github.com/ersilia-os/isaura.git
-cd isaura
-uv sync #creates an isolated virtual environment and installs all dependencies automatically.
-source .venv/bin/activate  # on Windows: .venv\Scripts\activate
-```
-
----
-
-### Verify installation
-
-Once installed, confirm everything is working by running:
-
-```bash
-isaura --help
-```
-
-You should see the list of available commands printed to your terminal.
-
----
-
-### Start local services
-
-Isaura relies on local infrastructure (MinIO for storage, and optionally Milvus + NNS for approximate search). Make sure Docker is running, then start everything with:
+Make sure Docker Desktop is open, then run:
 
 ```bash
 isaura engine --start
 ```
 
-Local dashboards once running:
-- MinIO Console: `http://localhost:9001`
+This starts a local MinIO instance and automatically creates the `isaura-public` and `isaura-private` buckets. You can explore the MinIO console at `http://localhost:9001` (user: `minioadmin123`, password: `minioadmin1234`).
 
-Default local credentials:
+---
+
+### Step 3 — (Optional) Set up remote credentials
+
+If you have access to Ersilia's remote store, add your cloud credentials interactively:
+
+```bash
+isaura configure --remote
 ```
-Username: minioadmin123
-Password: minioadmin1234
+
+You will be prompted for the cloud endpoint and access keys. Credentials are saved locally to `~/.isaura/.env` — nothing is sent anywhere.
+
+---
+
+### Step 4 — Verify your setup
+
+```bash
+isaura configure --test-credentials
 ```
-If you plan to upload/download large volumes of data, we recommend disabling Milvus if you will not use the NNS search, as the indexing can use a lot of memory:
+
+This checks connectivity for local and cloud (if configured) and prints a result table. All rows you care about should show `✓ connected`.
 
 ```
-docker stop milvus-standalone
+┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃ Target        ┃ Bucket         ┃ Result      ┃
+┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ Local         │ isaura-public  │ ✓ connected │
+│ Cloud public  │ isaura-public  │ ✓ connected │
+│ Cloud private │ isaura-private │ ✓ connected │
+└───────────────┴────────────────┴─────────────┘
 ```
 
 ---
 
 ## CLI
 
-### Common commands
+### Managing configuration
+
+```bash
+isaura configure                     # show current configuration
+isaura configure --remote            # add or update remote/cloud credentials
+isaura configure --update            # update a single credential interactively
+isaura configure --show-secrets      # show all credential values unmasked
+isaura configure --test-credentials  # test local and cloud connectivity
+```
+
+### Managing local services
+
+```bash
+isaura engine           # show status of Docker and MinIO
+isaura engine --start   # start local MinIO
+isaura engine --stop    # stop local MinIO
+```
+
+### Common data commands
 
 #### Write (store outputs)
 
@@ -159,7 +141,7 @@ isaura write -i data/ersilia_output.csv -m eos8a4x -v v2 -pn myproject --access 
 isaura read -i data/inputs.csv -m eos8a4x -v v2 -pn myproject -o data/outputs.csv
 ```
 
-#### Copy artifacts to local directory
+#### Copy artifacts to a local directory
 
 ```bash
 isaura copy -m eos8a4x -v v1 -pn myproject -o ~/Documents/isaura-backup/
@@ -173,7 +155,7 @@ isaura inspect -m eos8a4x -v v1 -o reports/available.csv
 
 #### Upload to cloud store
 
-The cloud only hosts two canonical buckets: `isaura-public` and `isaura-private`. If your local work uses a custom project name, you need to copy (or move) it into the appropriate canonical bucket first, then push to cloud.
+The cloud only hosts two canonical buckets: `isaura-public` and `isaura-private`. If your local work uses a custom project name, copy or move it into the appropriate canonical bucket first, then push.
 
 **Step 1 — write outputs to your local project:**
 
@@ -183,8 +165,6 @@ isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject --access 
 
 **Step 2 — copy (or move) into the canonical bucket:**
 
-Isaura routes each entry automatically based on the `--access` tag set during write: `public` → `isaura-public`, `private` → `isaura-private`.
-
 ```bash
 # copy (keeps data in myproject as well)
 isaura copy -m eos8a4x -v v1 -pn myproject
@@ -193,7 +173,7 @@ isaura copy -m eos8a4x -v v1 -pn myproject
 isaura move -m eos8a4x -v v1 -pn myproject
 ```
 
-**Step 3 — push the canonical bucket to cloud:**
+**Step 3 — push to cloud:**
 
 ```bash
 isaura push -m eos8a4x -v v1 -pn isaura-public
@@ -201,18 +181,7 @@ isaura push -m eos8a4x -v v1 -pn isaura-public
 isaura push -m eos8a4x -v v1 -pn isaura-private
 ```
 
-Cloud credentials must be set beforehand (in `.env` or exported in the terminal in each session):
-
-```bash
-export MINIO_ENDPOINT_CLOUD="<cloud-endpoint>"
-export MINIO_CLOUD_AK="<access-key>"        # public bucket
-export MINIO_CLOUD_SK="<secret-key>"
-export MINIO_PRIV_CLOUD_AK="<access-key>"   # private bucket
-export MINIO_PRIV_CLOUD_SK="<secret-key>"
-```
-
-> See [CONFIGURATION](docs/CONFIGURATION.md) for the full list of env vars.
-
+> Cloud credentials must be configured first with `isaura configure --remote`.
 
 ---
 
@@ -221,7 +190,9 @@ export MINIO_PRIV_CLOUD_SK="<secret-key>"
 ```python
 from isaura.manage import IsauraWriter, IsauraReader
 ```
-Write the precalculation
+
+Write a precalculation:
+
 ```python
 writer = IsauraWriter(
     input_csv="data/input.csv",
@@ -232,7 +203,9 @@ writer = IsauraWriter(
 )
 writer.write()
 ```
-Read the stored calculation
+
+Read stored results:
+
 ```python
 reader = IsauraReader(
     model_id="eos8a4x",
@@ -244,56 +217,21 @@ reader = IsauraReader(
 reader.read(output_csv="results.csv")
 ```
 
-More examples for CLI and API usage: **[API and CLI usage](docs/API_AND_CLI_USAGE.md)**
+More examples: **[API and CLI usage →](docs/API_AND_CLI_USAGE.md)**
 
 ---
 
 ## Configuration
 
-Isaura reads configuration from environment variables.
-
-### Recommended: `.env`
-
-Create a `.env` file in the repo root:
+Configuration is stored in `~/.isaura/.env` and created automatically on first run. You can view or update it at any time with:
 
 ```bash
-MINIO_ENDPOINT=http://127.0.0.1:9000
-NNS_ENDPOINT=http://127.0.0.1:8080
-DEFAULT_BUCKET_NAME=isaura-public
-DEFAULT_PRIVATE_BUCKET_NAME=isaura-private
+isaura configure                 # view current config
+isaura configure --update        # update any value interactively
+isaura configure --remote        # add cloud credentials
 ```
 
-### Cloud credentials (optional)
-
-```bash
-export MINIO_CLOUD_AK="<access_key>"
-export MINIO_CLOUD_SK="<secret_key>"
-
-export MINIO_PRIV_CLOUD_AK="<access_key>"
-export MINIO_PRIV_CLOUD_SK="<secret_key>"
-```
-> You can define those credentials in the .env as well
-
-See the full list: **[CONFIGURATION](docs/CONFIGURATION.md)**
-
----
-
-## MinIO Client (optional but recommended)
-
-Install `mc` to manage buckets:
-
-```bash
-brew install minio/stable/mc   # macOS
-# or Linux:
-curl -O https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x mc && sudo mv mc /usr/local/bin/
-```
-
-Configure alias:
-
-```bash
-mc alias set local http://localhost:9000 minioadmin123 minioadmin1234
-mc ls local
-```
+See the full list of available variables: **[CONFIGURATION →](docs/CONFIGURATION.md)**
 
 ---
 
@@ -315,7 +253,7 @@ PRs are welcome. Please run format + lint before pushing:
 uv run ruff format .
 ```
 
-If you’re changing CLI behavior, please update **[here](docs/API_AND_CLI_USAGE.md)**.
+If you're changing CLI behavior, please update **[here](docs/API_AND_CLI_USAGE.md)**.
 
 ---
 

--- a/README.old.md
+++ b/README.old.md
@@ -1,0 +1,326 @@
+<div align="center">
+
+<img src="./isaura/assets/isaura_v2.png" height="160" alt="Isaura logo" />
+
+### Ersilia’s Precalculation Store
+
+Fast, reproducible access to **precalculated model outputs** from the **Ersilia Model Hub** — with a CLI and Python API built for batch workflows.
+
+<br/>
+
+[![Python](https://img.shields.io/badge/Python-%3E%3D3.10-3776AB?style=flat-square&logo=python&logoColor=white)](#)
+[![uv](https://img.shields.io/badge/uv-supported-111111?style=flat-square&logo=astral&logoColor=white)](https://docs.astral.sh/uv/)
+[![Docker](https://img.shields.io/badge/Docker-required-2496ED?style=flat-square&logo=docker&logoColor=white)](https://www.docker.com/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000?style=flat-square&logo=python&logoColor=white)](https://github.com/psf/black)
+[![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)](#license)
+
+<br/>
+
+[Installation](#installation) ·
+[CLI](#cli) ·
+[Python API](#python-api) ·
+[Configuration](#configuration) ·
+[Docs](#docs) ·
+[Contributing](#contributing)
+
+</div>
+
+---
+
+## Why Isaura?
+Isaura is Ersilia’s precalculation store: it **persistently stores model outputs** so researchers can retrieve results instantly instead of repeatedly runningtime-consuming inference. This delivers a major research speed-up—especially in low-resource settings where compute, bandwidth, or infrastructure are limited—by turning repeated calculations into reusable shared artifacts. To support equitable access, Ersilia also provides **free access to public precalculations**, making high-value model outputs available even when local compute isn’t.
+
+Isaura provides a structured store for model results so you can:
+
+- ⚡ **Skip recomputation** by reusing precalculated outputs
+- 🧱 Keep artifacts **versioned and organized** (model → version → bucket/project)
+- 📦 Store and retrieve results via **S3-compatible object storage (MinIO)**  
+- 🔎 Enable **fast retrieval** using its fast engine developed on top of duckdb and for ANN uses vector search / indexing components (Milvus + NN service)
+
+---
+## Architecture (high level)
+
+* 📝 **Write:** `CLI / Python API → MinIO`
+  Precomputed outputs are stored as chunked artifacts (e.g., Parquet) under `model_id/version`, and Isaura updates lightweight registries (index/metadata/bloom) for deduplication and fast lookup.
+
+* 📥 **Read(exact):** `CLI / Python API → DuckDB query on MinIO → results`
+  Inputs are matched against the index, then the corresponding rows are fetched directly from the stored chunks.
+
+* ⚡ **Read (approx / ANN, optional):** `CLI / Python API → NN service (+ Milvus) → nearest match → exact fetch from MinIO`
+  For unseen inputs, the NN service finds the closest indexed compound(s); Isaura then retrieves the corresponding stored result from MinIO.
+
+
+See the deep dive: **[How it works →](docs/HOW_IT_WORKS.md)**
+
+---
+
+## Installation
+
+### Prerequisites
+
+Before installing Isaura, make sure you have the following:
+
+- **Python 3.10+** — [download here](https://www.python.org/downloads/)
+- **Git** — used to download the project ([download here](https://git-scm.com/downloads))
+- **Docker** — required to run local services like MinIO. [Download Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- **Docker Compose** — use docker-compose v2
+- **Write permissions**  — make sure you have write permissions in your filesystem
+
+---
+
+### Option A: Standard install *(recommended for most users)*
+
+This is the simplest path. Open a terminal and run the following commands one by one.
+
+**1. Clone the repository** — this downloads the project to your computer:
+
+```bash
+git clone https://github.com/ersilia-os/isaura.git
+```
+
+**2. Navigate into the project folder:**
+
+```bash
+cd isaura
+```
+
+**3a. Install Isaura through pip:**
+
+```bash
+conda activate <your_env>
+pip install -e .
+```
+
+The `-e` flag installs it in "editable" mode, meaning any changes you make to the source code are reflected immediately without reinstalling.
+
+---
+
+### Option B: Install with uv *(recommended for developers)*
+[uv](https://docs.astral.sh/uv/) is a faster alternative to pip. If you don't have it yet, [install it first](https://docs.astral.sh/uv/getting-started/installation/).
+
+```bash
+git clone https://github.com/ersilia-os/isaura.git
+cd isaura
+uv sync #creates an isolated virtual environment and installs all dependencies automatically.
+source .venv/bin/activate  # on Windows: .venv\Scripts\activate
+```
+
+---
+
+### Verify installation
+
+Once installed, confirm everything is working by running:
+
+```bash
+isaura --help
+```
+
+You should see the list of available commands printed to your terminal.
+
+---
+
+### Start local services
+
+Isaura relies on local infrastructure (MinIO for storage, and optionally Milvus + NNS for approximate search). Make sure Docker is running, then start everything with:
+
+```bash
+isaura engine --start
+```
+
+Local dashboards once running:
+- MinIO Console: `http://localhost:9001`
+
+Default local credentials:
+```
+Username: minioadmin123
+Password: minioadmin1234
+```
+If you plan to upload/download large volumes of data, we recommend disabling Milvus if you will not use the NNS search, as the indexing can use a lot of memory:
+
+```
+docker stop milvus-standalone
+```
+
+---
+
+## CLI
+
+### Common commands
+
+#### Write (store outputs)
+
+```bash
+isaura write -i data/ersilia_output.csv -m eos8a4x -v v2 -pn myproject --access public
+```
+
+#### Read (retrieve outputs)
+
+```bash
+isaura read -i data/inputs.csv -m eos8a4x -v v2 -pn myproject -o data/outputs.csv
+```
+
+#### Copy artifacts to local directory
+
+```bash
+isaura copy -m eos8a4x -v v1 -pn myproject -o ~/Documents/isaura-backup/
+```
+
+#### Inspect available entries
+
+```bash
+isaura inspect -m eos8a4x -v v1 -o reports/available.csv
+```
+
+#### Upload to cloud store
+
+The cloud only hosts two canonical buckets: `isaura-public` and `isaura-private`. If your local work uses a custom project name, you need to copy (or move) it into the appropriate canonical bucket first, then push to cloud.
+
+**Step 1 — write outputs to your local project:**
+
+```bash
+isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject --access public
+```
+
+**Step 2 — copy (or move) into the canonical bucket:**
+
+Isaura routes each entry automatically based on the `--access` tag set during write: `public` → `isaura-public`, `private` → `isaura-private`.
+
+```bash
+# copy (keeps data in myproject as well)
+isaura copy -m eos8a4x -v v1 -pn myproject
+
+# or move (removes data from myproject after copying)
+isaura move -m eos8a4x -v v1 -pn myproject
+```
+
+**Step 3 — push the canonical bucket to cloud:**
+
+```bash
+isaura push -m eos8a4x -v v1 -pn isaura-public
+# or for private data:
+isaura push -m eos8a4x -v v1 -pn isaura-private
+```
+
+Cloud credentials must be set beforehand (in `.env` or exported in the terminal in each session):
+
+```bash
+export MINIO_ENDPOINT_CLOUD="<cloud-endpoint>"
+export MINIO_CLOUD_AK="<access-key>"        # public bucket
+export MINIO_CLOUD_SK="<secret-key>"
+export MINIO_PRIV_CLOUD_AK="<access-key>"   # private bucket
+export MINIO_PRIV_CLOUD_SK="<secret-key>"
+```
+
+> See [CONFIGURATION](docs/CONFIGURATION.md) for the full list of env vars.
+
+
+---
+
+## Python API
+
+```python
+from isaura.manage import IsauraWriter, IsauraReader
+```
+Write the precalculation
+```python
+writer = IsauraWriter(
+    input_csv="data/input.csv",
+    model_id="eos8a4x",
+    model_version="v1",
+    bucket="my-project",
+    access="public",
+)
+writer.write()
+```
+Read the stored calculation
+```python
+reader = IsauraReader(
+    model_id="eos8a4x",
+    model_version="v1",
+    bucket="my-project",
+    input_csv="data/query.csv",
+    approximate=False,
+)
+reader.read(output_csv="results.csv")
+```
+
+More examples for CLI and API usage: **[API and CLI usage](docs/API_AND_CLI_USAGE.md)**
+
+---
+
+## Configuration
+
+Isaura reads configuration from environment variables.
+
+### Recommended: `.env`
+
+Create a `.env` file in the repo root:
+
+```bash
+MINIO_ENDPOINT=http://127.0.0.1:9000
+NNS_ENDPOINT=http://127.0.0.1:8080
+DEFAULT_BUCKET_NAME=isaura-public
+DEFAULT_PRIVATE_BUCKET_NAME=isaura-private
+```
+
+### Cloud credentials (optional)
+
+```bash
+export MINIO_CLOUD_AK="<access_key>"
+export MINIO_CLOUD_SK="<secret_key>"
+
+export MINIO_PRIV_CLOUD_AK="<access_key>"
+export MINIO_PRIV_CLOUD_SK="<secret_key>"
+```
+> You can define those credentials in the .env as well
+
+See the full list: **[CONFIGURATION](docs/CONFIGURATION.md)**
+
+---
+
+## MinIO Client (optional but recommended)
+
+Install `mc` to manage buckets:
+
+```bash
+brew install minio/stable/mc   # macOS
+# or Linux:
+curl -O https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x mc && sudo mv mc /usr/local/bin/
+```
+
+Configure alias:
+
+```bash
+mc alias set local http://localhost:9000 minioadmin123 minioadmin1234
+mc ls local
+```
+
+---
+
+## Docs
+
+* 📘 **How it works**: [here](docs/HOW_IT_WORKS.md)
+* ⚙️ **Configuration**: [here](docs/CONFIGURATION.md)
+* 🧰 **CLI and API reference**: [here](docs/API_AND_CLI_USAGE.md)
+* 🧪 **Benchmark**: [here](docs/BENCHMARK.md)
+* 🩹 **Troubleshooting / recovery**: [here](docs/TROUBLESHOOTING.md)
+
+---
+
+## Contributing
+
+PRs are welcome. Please run format + lint before pushing:
+
+```bash
+uv run ruff format .
+```
+
+If you’re changing CLI behavior, please update **[here](docs/API_AND_CLI_USAGE.md)**.
+
+---
+
+## About the Ersilia Open Source Initiative
+
+The [Ersilia Open Source Initiative](https://ersilia.io) is a tech-nonprofit organization fueling sustainable research in the Global South. Ersilia's main asset is the [Ersilia Model Hub](https://github.com/ersilia-os/ersilia), an open-source repository of AI/ML models for antimicrobial drug discovery.
+
+![Ersilia Logo](isaura/assets/Ersilia_Brand.png)

--- a/docs/API_AND_CLI_USAGE.md
+++ b/docs/API_AND_CLI_USAGE.md
@@ -3,7 +3,7 @@
 
 Isaura exposes a small set of high-level managers for writing, reading, and moving precalculated artifacts.
 
-> Tip: Most workflows are “write once, read many times”. After the first write, reads become fast.
+> Tip: Most workflows are "write once, read many times". After the first write, reads become fast.
 
 ---
 
@@ -14,14 +14,13 @@ from isaura.manage import (
   IsauraWriter,
   IsauraReader,
   IsauraCopy,
-  IsauraMover,
   IsauraRemover,
   IsauraInspect,
   IsauraPull,
   IsauraPush,
   IsauraStat,
 )
-````
+```
 
 ---
 
@@ -43,11 +42,7 @@ It uses `input`/`smiles` as the lookup key and stores the rest as payload column
 
 ## Write (upload/store results)
 
-Writes a CSV (or DataFrame) into the Isaura store for a given:
-
-* `model_id` (e.g. `eos8a4x`)
-* `model_version` (e.g. `v1`)
-* `bucket` (project namespace; default is `isaura-public`)
+Writes a CSV (or DataFrame) into the Isaura store for a given model ID, version, and project bucket.
 
 ```python
 from isaura.manage import IsauraWriter
@@ -56,11 +51,10 @@ with IsauraWriter(
   input_csv="data/ersilia_output.csv",
   model_id="eos8a4x",
   model_version="v1",
-  bucket="isaura-public",     # optional (defaults to public bucket)
-  access="public",            # metadata tag; typically public/private
-  endpoint=None,              # optional override MinIO endpoint
-  access_key=None,            # optional MinIO access key
-  secrete=None,               # optional MinIO secret key
+  bucket="myproject",
+  endpoint=None,        # optional MinIO endpoint override
+  access_key=None,      # optional MinIO access key
+  secrete=None,         # optional MinIO secret key
 ) as w:
   w.write()
 ```
@@ -74,10 +68,10 @@ from isaura.manage import IsauraWriter
 df = pd.read_csv("data/ersilia_output.csv")
 
 with IsauraWriter(
-  input_csv="data/ersilia_output.csv",  
+  input_csv="data/ersilia_output.csv",
   model_id="eos8a4x",
   model_version="v1",
-  bucket="isaura-public",
+  bucket="myproject",
 ) as w:
   w.write(df=df)
 ```
@@ -92,45 +86,22 @@ with IsauraWriter(
 ## Read (retrieve results)
 
 Reads rows matching inputs from a CSV (or DataFrame).
-You can run either:
-
-* **Exact** search: `approximate=False`
-* **Approximate/ANN** search: `approximate=True` (requires enough indexed data)
 
 ```python
 from isaura.manage import IsauraReader
 
-r = IsauraReader(
+with IsauraReader(
   model_id="eos8a4x",
   model_version="v1",
   input_csv="data/inputs.csv",
   approximate=False,
-  bucket="isaura-public",
+  bucket="myproject",
   endpoint=None,
   access_key=None,
   secrete=None,
-)
-
-df = r.read(output_csv="data/outputs.csv")
+) as r:
+  df = r.read(output_csv="data/outputs.csv")
 ```
-
-### Approximate retrieval (ANN)
-
-```python
-r = IsauraReader(
-  model_id="eos8a4x",
-  model_version="v1",
-  input_csv="data/inputs.csv",
-  approximate=True,
-)
-
-df = r.read()
-```
-
-**Notes**
-
-* ANN is only enabled when the index size is above a minimum (`MIN_NNS_RESULT_SIZE`).
-* ANN contacts an NN service using `NNS_ENDPOINT` and may trigger/ensure index building.
 
 ---
 
@@ -143,13 +114,10 @@ from isaura.manage import IsauraInspect
 
 insp = IsauraInspect(
   cloud=False,
-  project_name=None,
+  project_name="myproject",
   access="both",     # "public" | "private" | "both"
   endpoint=None,
 )
-
-# List unique inputs that exist and which bucket owns them
-df_available = insp.list_available(output_csv="reports/available_inputs.csv")
 
 # Check if a given input CSV is available
 df_check = insp.inspect_inputs(
@@ -158,74 +126,68 @@ df_check = insp.inspect_inputs(
 )
 
 # Inspect models in a bucket (model_id/version + entry counts)
-models = insp.inspect_models(bucket="isaura-public")
+models = insp.inspect_models(bucket="myproject")
 ```
 
 ---
 
-## Copy / Move / Remove
+## Persist / Remove
 
-These are “server-side” operations on stored artifacts for a model/version/bucket.
+These are server-side operations on stored artifacts for a model/version/bucket.
 
 ```python
-from isaura.manage import IsauraCopy, IsauraMover, IsauraRemover
+from isaura.manage import IsauraCopy, IsauraRemover
 
-IsauraCopy(model_id="eos8a4x", model_version="v1", bucket="isaura-public", output_dir="backup/").copy()
+# Persist: route rows from a project bucket into isaura-public / isaura-private
+IsauraCopy(model_id="eos8a4x", model_version="v1", bucket="myproject").copy()
 
-IsauraMover(model_id="eos8a4x", model_version="v1", bucket="isaura-public", output_dir="newplace/").move()
-
-IsauraRemover(model_id="eos8a4x", model_version="v1", bucket="isaura-public", output_dir=None).remove()
+# Remove a model/version from a bucket
+IsauraRemover(model_id="eos8a4x", model_version="v1", bucket="myproject").remove()
 ```
 
 ---
 
-## Pull / Push (cloud sync workflows)
+## Pull / Push (cloud sync)
 
 ### Pull
 
-Pulls from cloud into a local workspace by reading from the cloud endpoint and materializing objects.
+Downloads outputs from the cloud store into your local MinIO.
 
 ```python
 from isaura.manage import IsauraPull
 
-p = IsauraPull(
+with IsauraPull(
   model_id="eos8a4x",
   model_version="v1",
   bucket="isaura-public",
   input_csv="data/inputs.csv",
-)
-p.pull()
+) as p:
+  p.pull()
 ```
 
 ### Push
 
-Pushes local public/private data to cloud by:
-
-1. listing available inputs,
-2. splitting by bucket,
-3. reading locally,
-4. writing to cloud.
+Uploads local public/private data to the cloud.
 
 ```python
 from isaura.manage import IsauraPush
 
-IsauraPush(model_id="eos8a4x", model_version="v1", bucket="my-project").push()
+IsauraPush(model_id="eos8a4x", model_version="v1", bucket="myproject").push()
 ```
 
-> Cloud credentials must be provided via env vars (see `docs/CONFIGURATION.md`).
+> Cloud credentials must be provided via environment variables (see `docs/CONFIGURATION.md`).
 
 ---
 
 ## Stats (inventory report)
 
-Generate a JSON report of what’s stored, including optional column counts.
+Generate a JSON report of what's stored, including optional column counts.
 
 ```python
 from isaura.manage import IsauraStat
 
 st = IsauraStat(
-  project_name=None,
-  access="both",
+  project_name="isaura-public",
   cloud=False,
   include_columns=True,
   include_column_names=False,
@@ -239,7 +201,7 @@ The stats report includes:
 * buckets scanned
 * model counts by bucket
 * molecules per model
-* histogram of “how many models each molecule appears in”
+* histogram of "how many models each molecule appears in"
 * optional parquet column info (best effort)
 
 <br>
@@ -247,200 +209,181 @@ The stats report includes:
 ---
 
 
-# CLI usage
-
-Isaura ships with a CLI for writing/reading/store operations and local engine management.
-
-> The CLI mirrors the Python API: write/read/inspect/copy/move/remove + engine start.
+# CLI reference
 
 ---
 
-## Quick start
+## Configuration
 
 ```bash
-isaura engine --start
-````
-
-Local dashboards:
-
-* MinIO Console: `http://localhost:9001`
-* Milvus API: `http://localhost:8080`
-
----
-
-## Common commands
-
-### Write (upload/store results)
-
-Uploads outputs for a model/version from a CSV.
-Your CSV should contain an input identifier column (`input` preferred; `smiles` supported).
-
-```bash
-isaura write \
-  -i data/ersilia_output.csv \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject \
-  --access public
-```
-
-**Behavior**
-
-* Skips duplicates using the bloom/index registry.
-* Persists metadata to `access.json`.
-
----
-
-### Read (retrieve results)
-
-Fetches stored rows corresponding to inputs in a CSV.
-
-```bash
-isaura read \
-  -i data/inputs.csv \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject \
-  -o data/outputs.csv
-```
-
-### Read with approximate matching (ANN)
-
-```bash
-isaura read \
-  -i data/inputs.csv \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject \
-  -o data/outputs.csv \
-  -nn
-```
-
-**Notes**
-
-* ANN requires a sufficiently large index.
-* Uses `NNS_ENDPOINT` and may trigger/build ANN index server-side.
-
----
-
-## Inspect & catalog
-
-### Inspect inputs (validate availability)
-
-```bash
-isaura inspect inputs \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject \
-  -i data/inputs.csv \
-  -o reports/inspect_report.csv
-```
-
-### List available entries for a model/version
-
-```bash
-isaura inspect \
-  -m eos8a4x \
-  -v v1 \
-  -o reports/available.csv
-```
-
-### Catalog models in a project (bucket)
-
-```bash
-isaura catalog -pn myproject
+isaura configure                     # show current configuration
+isaura configure --remote            # add or update remote/cloud credentials
+isaura configure --update            # update a single credential interactively
+isaura configure --show-secrets      # show all credential values unmasked
+isaura configure --test-credentials  # test local and cloud connectivity
 ```
 
 ---
 
-## Transfer operations
-
-### Copy artifacts (server → local)
+## Local services
 
 ```bash
-isaura copy \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject \
-  -o ~/Documents/isaura-backup/
-```
-
-### Move artifacts (server-side relocate)
-
-```bash
-isaura move \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject
-```
-
-### Remove artifacts (permanent)
-
-```bash
-isaura remove \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject \
-  --yes
+isaura engine           # show Docker and MinIO status
+isaura engine --start   # start local MinIO
+isaura engine --stop    # stop local MinIO
 ```
 
 ---
 
-## Cloud sync
+## Projects
 
-### Pull from cloud → local
-
-```bash
-isaura pull \
-  -m eos8a4x \
-  -v v1 \
-  -pn isaura-public \
-  -i data/inputs.csv
-```
-
-### Push local → cloud
+A **project** is a named MinIO bucket used as a staging area.
 
 ```bash
-isaura push \
-  -m eos8a4x \
-  -v v1 \
-  -pn myproject
+isaura info                  # list local projects (name, access, created, path)
+isaura info --remote         # list remote projects
+
+isaura create -pn myproject --access public    # create a new local project
+isaura destroy -pn myproject                   # destroy entire project
+isaura destroy -pn myproject -m eos8a4x -v v1  # destroy a specific model version
 ```
 
-Cloud auth is via env vars:
-
-* `MINIO_CLOUD_AK`, `MINIO_CLOUD_SK`
-* `MINIO_PRIV_CLOUD_AK`, `MINIO_PRIV_CLOUD_SK`
-* `MINIO_ENDPOINT_CLOUD`
+> `isaura-public` and `isaura-private` are reserved — they cannot be fully destroyed, but individual model versions inside them can be removed.
 
 ---
 
-## Configuration (env vars)
+## Write
 
-Common:
+Store model outputs in a project bucket:
 
-* `MINIO_ENDPOINT` (default `http://127.0.0.1:9000`)
-* `NNS_ENDPOINT` (default `http://127.0.0.1:8080`)
-* `DEFAULT_BUCKET_NAME` (default `isaura-public`)
-* `DEFAULT_PRIVATE_BUCKET_NAME` (default `isaura-private`)
-* `BATCH`, `FLUSH_EVERY`, `TIMEOUT`
+```bash
+isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject
+```
 
-Recommended: define them in a `.env` file (loaded automatically if `python-dotenv` is installed).
+| Flag | Description |
+|---|---|
+| `-i, --input` | Input CSV (required) |
+| `-m, --model-id` | Ersilia model ID (required) |
+| `-v, --version` | Model version, default `v1` |
+| `-pn, --project-name` | Target bucket (required) |
 
----
-
-## Reference: flags (most used)
-
-| Flag                  | Meaning                            |
-| --------------------- | ---------------------------------- |
-| `-i, --input-file`    | Input CSV                          |
-| `-o, --output-file`   | Output CSV                         |
-| `-m, --model`         | Model ID (e.g. `eos8a4x`)          |
-| `-v, --version`       | Model version (e.g. `v1`)          |
-| `-pn, --project-name` | Bucket/project name                |
-| `--access`            | `public` / `private` / `both`      |
-| `-nn`                 | Enable approximate (ANN) retrieval |
-| `--cloud`             | Use cloud endpoint/credentials     |
+> If the filename contains a model ID that doesn't match `--model-id`, isaura will error before writing anything.
 
 ---
 
+## Read
+
+Retrieve stored outputs for a set of inputs:
+
+```bash
+# explicit version
+isaura read -i data/inputs.csv -m eos8a4x -v v1 -pn myproject -o data/outputs.csv
+
+# auto-resolve to latest stored version
+isaura read -i data/inputs.csv -m eos8a4x -pn myproject -o data/outputs.csv
+```
+
+| Flag | Description |
+|---|---|
+| `-i, --input` | Input CSV (required) |
+| `-m, --model-id` | Ersilia model ID (required) |
+| `-v, --version` | Model version — defaults to latest stored version if omitted |
+| `-pn, --project-name` | Source bucket (required) |
+| `-o, --output` | Output CSV path (optional — prints row count if omitted) |
+| `-V, --verbose` | Show detailed internal logs |
+
+---
+
+## Inspect
+
+Check which molecules from an input CSV are already cached:
+
+```bash
+isaura inspect --model_id eos8a4x -v v1 --access public -i data/inputs.csv -o reports/available.csv
+```
+
+| Flag | Description |
+|---|---|
+| `--model_id, -m` | Ersilia model ID (required) |
+| `-v, --version` | Model version, default `v1` |
+| `-pn, --project-name` | Restrict search to this bucket |
+| `--access` | `public`, `private`, or `both` — ignored when `--project-name` is set |
+| `-i, --input` | Input CSV to check (required) |
+| `-o, --output` | Output CSV path (required) |
+| `-r, --remote` | Query the remote store (default: local) |
+
+---
+
+## Catalog
+
+List all models stored in a project:
+
+```bash
+isaura catalog -pn myproject           # local
+isaura catalog -pn isaura-public -r    # remote (requires cloud credentials)
+```
+
+---
+
+## Publishing to the cloud
+
+**Step 1 — write to a local project:**
+
+```bash
+isaura write -i data/ersilia_output.csv -m eos8a4x -v v1 -pn myproject
+```
+
+**Step 2 — persist into the canonical bucket:**
+
+```bash
+isaura persist -m eos8a4x -v v1 -pn myproject
+```
+
+Routes molecules to `isaura-public` or `isaura-private` based on the project's access setting.
+
+**Step 3 — push to cloud:**
+
+```bash
+isaura push -m eos8a4x -v v1 -pn isaura-public
+```
+
+> Cloud credentials must be configured first with `isaura configure --remote`.
+
+---
+
+## Pull
+
+Download precalculations from the remote store into local MinIO:
+
+```bash
+# explicit version
+isaura pull -i data/inputs.csv -m eos8a4x -v v1 -pn isaura-public
+
+# auto-resolve to latest stored version
+isaura pull -i data/inputs.csv -m eos8a4x -pn isaura-public
+```
+
+| Flag | Description |
+|---|---|
+| `-i, --input` | Input CSV (required) |
+| `-m, --model-id` | Ersilia model ID (required) |
+| `-v, --version` | Model version — defaults to latest stored version if omitted |
+| `-pn, --project-name` | Remote bucket to pull from |
+| `-V, --verbose` | Show detailed internal logs |
+
+---
+
+## Stats
+
+Generate a JSON inventory of all models in a bucket:
+
+```bash
+isaura stats -pn isaura-public -o ./reports
+isaura stats -pn myproject --remote -o ./reports
+```
+
+| Flag | Description |
+|---|---|
+| `-pn, --project-name` | Bucket to scan (required) |
+| `-o, --output-dir` | Folder to write the JSON report (required) |
+| `-r, --remote` | Scan the remote store (default: local) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -124,13 +124,13 @@ MINIO_PRIV_CLOUD_SK="<secret_key>"
 
 * ☁️ Set `MINIO_ENDPOINT_CLOUD`
 * 🔐 Export the correct cloud credentials (public and/or private)
-* 🧭 Use `--cloud` where supported (or cloud-enabled Python classes)
+* 🧭 Use `--remote` where supported (or cloud-enabled Python classes)
 
 ---
 
 ## 🧷 Notes
 
-* 🔎 ANN mode depends on the NN service and an index being built; if ANN fails, fall back to exact search.
+* 🔎 Approximate (ANN) search is available in the Python API but disabled in the CLI. It depends on the NNS service being running and an index being built.
 
 ---
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -1,4 +1,4 @@
-## How it wotks
+## How it works
 
 <p align="center">
   <img src="../isaura/assets/isaura_mechanism.png" alt="Isaura logo"><br><br>
@@ -8,147 +8,105 @@
 
 ### Write / ingest
 - Accepts **Ersilia outputs format** for any model
-- Uses **DuckDB** as the **writing engine** to produce Parquet chunks
-- Stores everything in **MinIO** (object storage)
+- Uses **PyArrow** to produce Parquet chunks stored in **MinIO** (S3-compatible object storage)
+- Deduplicates inputs using a **Bloom filter** before writing
 
 ### Read / fetch
 You provide a **CSV file** containing a list of inputs.
 
-- **Exact search**
-  - Isaura uses **DuckDB** to query Parquet directly from MinIO
-  - Returns results in **Ersilia outputs format**
-
-- **Approximate search**
-  - Isaura uses **Milvus** (via **NNS**) to find the **top-1 most similar stored input**
-  - Then Isaura fetches the cached output for that matched input using **DuckDB + MinIO**
-  - Returns results in **Ersilia outputs format**
+- Isaura uses **DuckDB** to query Parquet directly from MinIO
+- Returns results in **Ersilia outputs format**
 
 ---
 
 ## Architecture
 
-- User interacts through **Isaura CLI**
-- **DuckDB** is the query + write engine over Parquet
-- **MinIO** stores Parquet data + indexes
-- **Milvus** stores input fingerprints for approximate search
-- **NNS** is a Go-based REST API sitting in front of Milvus for high-performance ingest/query from the Milvus:
-  - https://github.com/ersilia-os/nn-search/tree/main/api
+- User interacts through the **Isaura CLI** or **Python API**
+- **DuckDB** is the query engine over Parquet for exact retrieval
+- **MinIO** stores Parquet data, Bloom filters, and index files
+- **Approximate search** (Milvus/NNS) is available in the Python API but disabled in the CLI
 
 ---
 
-## Components (quick summary)
-
-### DuckDB
-Isaura’s compute engine for:
-- writing Parquet chunks during ingestion
-- querying Parquet during exact retrieval
-
-DuckDB reads/writes data in MinIO via its S3/HTTPFS support.
-
-**DuckDB “URL” pattern used by Isaura (logical path):**
-- Parquet data:
-  - `s3://<bucket>/<eos_id>/<version>/data/chunk_*.parquet`
-- Bloom filter index:
-  - `s3://<bucket>/<eos_id>/<version>/bloom.pkl`
-- Access control metadata:
-  - `s3://<bucket>/<eos_id>/<version>/access.json`
-
-> Note: With MinIO, DuckDB is typically configured with an S3 endpoint (e.g. `http://<minio-host>:9000`) plus credentials; the object paths remain `s3://...`.
-
-### MinIO
-Object storage for:
-- cached outputs as Parquet chunk files
-- `bloom.pkl` membership index
-- `access.json` access metadata per input
-
-### Milvus (approximate-only)
-Milvus is used **only** for approximate search.
-
-- You query with a list of inputs
-- Milvus returns, for each input, the **top-1 nearest** stored input
-- Similarity: **Jaccard similarity**
-- Current representation: **1024-bit Morgan fingerprint** (CPD inputs)
-- Collection naming convention:
-  - `{ersilia_eos_id}_{version}`
-
-Milvus stores *input fingerprints and identifiers*, not full Ersilia outputs.
-
-### NNS (Milvus REST gateway)
-NNS is a Go-based REST API server to ingest/query Milvus with high performance:
-- https://github.com/ersilia-os/nn-search/tree/main/api
-
----
-
-## Projects (buckets) and defaults
+## Projects (buckets)
 
 Isaura organizes data in **projects**, backed by MinIO buckets.
 
-### Default projects
-- `isaura-public`
-- `isaura-private`
+### Canonical buckets
+- `isaura-public` — finalized, publicly accessible precalculations
+- `isaura-private` — finalized, restricted precalculations
 
-You can create custom projects/buckets as needed (see CLI commands below / `--help`).
+### Project buckets
+Custom project buckets (e.g. `ersilia-hiv`) are **staging areas**. You write data there first, then use `isaura persist` to route molecules into the canonical buckets based on their access tag (`public` → `isaura-public`, `private` → `isaura-private`).
 
 ---
 
 ## Storage layout
 
-Example structure for a single model (`eosid`) and version:
+Example structure for a single model and version:
 
 ```
-isaura-public/
-eosid/
-version/
-bloom.pkl
-access.json
-data/
-chunk_{idx}.parquet
-
+<bucket>/
+  eos8a4x/
+    v1/
+      tranches/
+        bloom.pkl           ← Bloom filter for fast membership checks
+        index.json          ← maps molecule → (row, chunk) coordinates
+        access.json         ← access tag per molecule (public/private)
+        catalog.json        ← entry count + chunk count metadata
+        data/
+          col=A/row=0/
+            chunk_0.parquet
+            chunk_1.parquet
+            ...
 ```
-
-### Parquet chunking rule
-Each `chunk_{idx}.parquet` contains **up to 2,000,000 rows** (2M max) for performance reasons (DuckDB scan efficiency / row grouping).
 
 ---
 
-## Fast “does this input exist?” checks (Bloom filter)
+## Parquet chunking
 
-Isaura keeps a Bloom filter per `(project, model, version)` at:
+Chunk size depends on the model's **number of output columns**:
 
-- `<bucket>/<eos_id>/<version>/bloom.pkl`
+| Model type | Output columns | Max rows per chunk |
+|---|---|---|
+| Narrow | < 100 | 2,000,000 |
+| Wide | ≥ 100 | 100,000 |
 
-This allows Isaura to quickly rule out missing inputs before doing heavier Parquet scans.
+This keeps individual files at a manageable size — a model with 500 output columns × 2M rows would produce an extremely large file. Smaller chunks also allow isaura to download only the files that contain your query molecules.
 
-> Bloom filters may produce false positives, but not false negatives.
+---
+
+## Fast membership checks (Bloom filter)
+
+Isaura keeps a Bloom filter per `(bucket, model, version)` at:
+
+```
+<bucket>/<model_id>/<version>/tranches/bloom.pkl
+```
+
+This allows Isaura to quickly rule out missing inputs before doing any Parquet scans.
+
+> Bloom filters may produce false positives, but never false negatives.
 
 ---
 
 ## Access control with `access.json`
 
-Each `(project, model, version)` also includes:
+Each `(bucket, model, version)` stores:
 
-- `<bucket>/<eos_id>/<version>/access.json`
+```
+<bucket>/<model_id>/<version>/tranches/access.json
+```
 
-This file stores **inputs and their access classification** (e.g. `public` or `private`).
-
-Isaura uses this to decide where results should live in the default buckets.
+This file records each molecule's access classification (`public` or `private`). When you run `isaura persist`, isaura reads this file and routes molecules to `isaura-public` or `isaura-private` accordingly.
 
 ---
 
-## Copying calculations into default buckets (and Milvus registration)
+## Persisting into canonical buckets
 
-When you **copy calculations** for a given:
-- `project + model (eos_id) + version`
+When you run `isaura persist -m eos8a4x -v v1 -pn myproject`, isaura:
 
-Isaura performs the following:
-
-1. Reads `<custom_project>/<eos_id>/<version>/access.json`
-2. For each input:
-   - writes/stores it into `isaura-public` **or** `isaura-private` based on access metadata
-3. Updates the Bloom filter(s) accordingly (`bloom.pkl`)
-4. **Registers inputs into Milvus** (this happens during copy from a custom project to the default buckets)
-
-This means:
-- Inputs are **indexed in Milvus** at the moment they become part of the default store
-- Approximate search operates over what has been copied/registered into the default store
-
+1. Reads `myproject/eos8a4x/v1/tranches/access.json`
+2. For each molecule, routes it to `isaura-public` or `isaura-private` based on its access tag
+3. Updates the Bloom filter and index in the destination bucket
+4. Uploads an updated `catalog.json`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -201,7 +201,7 @@ Fix:
 * Or validate inputs using inspect:
 
   ```bash
-  isaura inspect inputs -i data/inputs.csv -o reports/inspect_report.csv -m eosxxxx -v v1 -pn myproject
+  isaura inspect --model_id eosxxxx -v v1 --access public -i data/inputs.csv -o reports/inspect_report.csv
   ```
 
 ### Wrong input header

--- a/isaura/base.py
+++ b/isaura/base.py
@@ -20,6 +20,7 @@ from isaura.helpers import (
   MINIO_MULTIPART_CHUNKSIZE,
   MINIO_MAX_CONCURRENCY,
   logger,
+  console,
   rss_mb,
   chunk_row_limit,
   chunk_write_batch_rows,
@@ -1261,16 +1262,18 @@ class _BaseTransfer:
       tp += added
       if added:
         apprx_inputs.extend(chunk[mol_col].astype(str).tolist())
-    wt.finalize(schema_cols=schema_cols)
+    with console.status("Storing to local MinIO...", spinner="dots"):
+      wt.finalize(schema_cols=schema_cols)
+    actual = len(wt.bi.index) if wt.bi.index is not None else tp
     if apprx_inputs:
       try:
         post_apprx(pd.DataFrame({"input": apprx_inputs}), self.collection)
       except Exception as e:
         logger.warning(f"[pull] post_apprx failed: {e}")
     logger.debug(
-      f"[pull] done rows={tp} chunk_limit={self._chunk_row_limit()} output_dim={self._get_output_dimension()} elapsed={time.time() - t0:.1f}s rss={rss_mb():.0f}MB"
+      f"[pull] done rows={actual} chunk_limit={self._chunk_row_limit()} output_dim={self._get_output_dimension()} elapsed={time.time() - t0:.1f}s rss={rss_mb():.0f}MB"
     )
-    return (tp, 0)
+    return (actual, 0)
 
   def _dump(self):
     """Download every object in the bucket to self.output_dir, preserving key paths."""

--- a/isaura/base.py
+++ b/isaura/base.py
@@ -1,4 +1,5 @@
 import boto3, duckdb, gc, json, os, pandas as pd, pickle, pyarrow as pa, pyarrow.parquet as pq, requests, sys, time, uuid
+from isaura.const import INPUT_C as _INPUT_C
 from botocore.config import Config
 from boto3.s3.transfer import TransferConfig
 from pybloom_live import ScalableBloomFilter
@@ -214,7 +215,7 @@ class MinioStore:
       url = f"{self.endpoint.rstrip('/')}/minio/health/ready"
       resp = requests.get(url, timeout=3)
       if resp.status_code == 200:
-        logger.info(f"MinIO server healthy at {url}")
+        logger.debug(f"MinIO server healthy at {url}")
         return True
       logger.error(
         f"MinIO health check failed. Maybe the minio containers not running[{resp.status_code}]: {resp.text.strip()}"
@@ -382,7 +383,7 @@ class BloomIndex:
       self.store.download_file(self.bucket, self.bloom_key, self.local_bloom)
       with open(self.local_bloom, "rb") as f:
         self.sbf = pickle.load(f)
-      logger.info(f"loaded bloom {self.bucket}/{self.bloom_key}")
+      logger.debug(f"loaded bloom {self.bucket}/{self.bloom_key}")
     except Exception:
       self.sbf = ScalableBloomFilter(
         mode=ScalableBloomFilter.SMALL_SET_GROWTH, initial_capacity=initial_capacity, error_rate=error_rate
@@ -393,13 +394,13 @@ class BloomIndex:
         self.store.download_file(self.bucket, self.index_key, self.local_index)
         with open(self.local_index, "r", encoding="utf-8") as f:
           self.index = json.load(f)
-        logger.info(f"loaded index {self.bucket}/{self.index_key} entries={len(self.index)}")
+        logger.debug(f"loaded index {self.bucket}/{self.index_key} entries={len(self.index)}")
       except Exception:
         self.index = {}
-        logger.info("created new index")
+        logger.debug("created new index")
     else:
       self.index = None
-      logger.info("skipped index load")
+      logger.debug("skipped index load")
     self._added = 0
 
   def seen(self, v):
@@ -617,12 +618,12 @@ class ChunkState:
     keys, t = (self._list_chunks(), "data")
     if not keys:
       self.state[t] = {"next": 1, "open": None, "rows": 0}
-      logger.info("chunk new: next=1")
+      logger.debug("chunk new: next=1")
       return
     last = keys[-1]
     idx = self._chunk_idx(last)
     self.state[t] = {"next": idx + 1, "open": None, "rows": 0}
-    logger.info(f"chunk next: {idx + 1}")
+    logger.debug(f"chunk next: {idx + 1}")
 
   def _list_chunks(self):
     """Return a sorted list of Parquet chunk keys for this model from MinIO."""
@@ -772,7 +773,7 @@ class ChunkState:
           st["next"] += 1
           st["open"] = None
           st["rows"] = 0
-          logger.info(f"flush: closed chunk next={st['next']}")
+          logger.debug(f"flush: closed chunk next={st['next']}")
       finally:
         try:
           os.remove(tmp)
@@ -809,7 +810,7 @@ class ChunkState:
     st = self.state["data"]
     remaining = len(df)
     start = 0
-    logger.info(f"flush_df: chunk rows={remaining} cols={len(schema_cols or [])} limit={self.max_rows}")
+    logger.debug(f"flush_df: chunk rows={remaining} cols={len(schema_cols or [])} limit={self.max_rows}")
     if st["open"]:
       tmp = os.path.join(self.tmpdir, f"open_{uuid.uuid4().hex}.parquet")
       try:
@@ -822,7 +823,7 @@ class ChunkState:
           st["rows"] += take
           remaining -= take
           start += take
-          logger.info(f"flush_df: appended chunk idx={st['next']} +{take} -> {st['rows']}")
+          logger.debug(f"flush_df: appended chunk idx={st['next']} +{take} -> {st['rows']}")
         if st["rows"] >= self.max_rows:
           st["next"] += 1
           st["open"] = None
@@ -918,14 +919,14 @@ class _SinkWriter:
       added = len(new_df)
       self.last_added_inputs = []
       if added == 0:
-        logger.info(f"[sink] in={n_in} added=0 seen={skipped_seen} blank={skipped_blank}")
+        logger.debug(f"[sink] in={n_in} added=0 seen={skipped_seen} blank={skipped_blank}")
         return 0
       self.last_added_inputs = inputs.loc[not_seen].tolist()
       for smi in inputs.loc[not_seen]:
         self.bi.register(smi, rc=(1, 1))
       self.buffers.append(new_df)
       self.buf_rows += added
-      logger.info(
+      logger.debug(
         f"[sink] in={n_in} added={added} seen={skipped_seen} blank={skipped_blank} buf={self.buf_rows}/{self.max_rows}"
       )
       if self.buf_rows >= self.max_rows:
@@ -941,7 +942,7 @@ class _SinkWriter:
     if not parts:
       return
     merged = pd.concat(parts, ignore_index=True)
-    logger.info(f"[sink] flushing {len(merged)} rows")
+    logger.debug(f"[sink] flushing {len(merged)} rows")
     self.chunk_state.flush_df(merged, self.schema_cols)
     self.buffers = []
     self.buf_rows = 0
@@ -997,7 +998,7 @@ def upload_catalog_json(store, bucket, base_prefix, entries, chunks, tmpdir):
       json.dump(cat, f, separators=(",", ":"))
     key = f"{base_prefix.strip('/')}/{CATALOG_FILE}"
     store.upload_file(local, bucket, key)
-    logger.info(f"[catalog] {CATALOG_FILE} -> {bucket}/{key} entries={entries} chunks={chunks}")
+    logger.debug(f"[catalog] {CATALOG_FILE} -> {bucket}/{key} entries={entries} chunks={chunks}")
   except Exception as e:
     logger.warning(f"catalog.json upload failed: {e}")
   finally:
@@ -1204,7 +1205,8 @@ class _BaseTransfer:
     apprx_inputs = []
     _tp = wt.add_rows(df)
     if _tp != 0:
-      apprx_inputs.extend(df["input"].astype(str).tolist())
+      mol_col = next((c for c in _INPUT_C if c in df.columns), df.columns[0])
+      apprx_inputs.extend(df[mol_col].astype(str).tolist())
     tp += _tp
     if wt:
       wt.finalize(schema_cols=list(df.keys()))
@@ -1212,7 +1214,7 @@ class _BaseTransfer:
       apprx_df = pd.DataFrame({"input": apprx_inputs})
       post_apprx(apprx_df, self.collection)
       del apprx_df
-    logger.info(f"[pull] done rows={tp} elapsed={time.time() - t0:.1f}s rss={rss_mb():.0f}MB")
+    logger.debug(f"[pull] done rows={tp} elapsed={time.time() - t0:.1f}s rss={rss_mb():.0f}MB")
     return (tp, tu)
 
   def _pull_batched(self, chunks):
@@ -1237,22 +1239,24 @@ class _BaseTransfer:
     tp = 0
     apprx_inputs = []
     schema_cols = None
+    mol_col = None
     for chunk in chunks:
       if chunk is None or chunk.empty:
         continue
       if schema_cols is None:
         schema_cols = list(chunk.columns)
+        mol_col = next((c for c in _INPUT_C if c in chunk.columns), schema_cols[0])
       added = wt.add_rows(chunk)
       tp += added
       if added:
-        apprx_inputs.extend(chunk["input"].astype(str).tolist())
+        apprx_inputs.extend(chunk[mol_col].astype(str).tolist())
     wt.finalize(schema_cols=schema_cols)
     if apprx_inputs:
       try:
         post_apprx(pd.DataFrame({"input": apprx_inputs}), self.collection)
       except Exception as e:
         logger.warning(f"[pull] post_apprx failed: {e}")
-    logger.info(
+    logger.debug(
       f"[pull] done rows={tp} chunk_limit={self._chunk_row_limit()} output_dim={self._get_output_dimension()} elapsed={time.time() - t0:.1f}s rss={rss_mb():.0f}MB"
     )
     return (tp, 0)

--- a/isaura/base.py
+++ b/isaura/base.py
@@ -225,6 +225,14 @@ class MinioStore:
       logger.error(f"Unexpected error during MinIO health check: {e}")
     return False
 
+  def credential_check(self) -> bool:
+    """Return True if the current credentials are accepted by the server."""
+    try:
+      self.client.list_buckets()
+      return True
+    except Exception:
+      return False
+
   def ensure_bucket(self, bucket):
     """Create the bucket if it does not already exist. Exits on failure."""
     try:

--- a/isaura/base.py
+++ b/isaura/base.py
@@ -238,20 +238,30 @@ class MinioStore:
     """Create the bucket if it does not already exist. Exits on failure."""
     try:
       self.client.head_bucket(Bucket=bucket)
-    except Exception as e:
-      logger.error(e)
+    except Exception:
       try:
         self.client.create_bucket(Bucket=bucket)
       except Exception as e:
         logger.error(e)
         sys.exit(1)
 
+  def require_bucket(self, bucket):
+    """Exit with a helpful error if the bucket does not exist."""
+    try:
+      self.client.head_bucket(Bucket=bucket)
+    except Exception:
+      logger.error(
+        f"Project [bold]{bucket}[/bold] does not exist. "
+        f"Run [bold]isaura info[/bold] to see available projects or [bold]isaura create -pn {bucket} --access <public|private>[/bold] to create it."
+      )
+      sys.exit(1)
+
   def download_file(self, bucket, key, local):
     """Download an object from MinIO to a local path. Raises on missing key."""
     try:
       self.client.download_file(bucket, key, local, Config=self.transfer_config)
     except Exception as e:
-      logger.warning(f"The file {key} is not found in bucket {bucket}. Details -> {e}")
+      logger.debug(f"The file {key} is not found in bucket {bucket}. Details -> {e}")
       raise
 
   def upload_file(self, local, bucket, key, extra_args=None):
@@ -388,7 +398,7 @@ class BloomIndex:
       self.sbf = ScalableBloomFilter(
         mode=ScalableBloomFilter.SMALL_SET_GROWTH, initial_capacity=initial_capacity, error_rate=error_rate
       )
-      logger.info("created new bloom")
+      logger.debug("created new bloom")
     if load_index:
       try:
         self.store.download_file(self.bucket, self.index_key, self.local_index)
@@ -755,7 +765,7 @@ class ChunkState:
     st = self.state["data"]
     remaining = len(rows)
     start = 0
-    logger.info(f"flush: chunk rows={remaining} cols={len(schema_cols or [])} limit={self.max_rows}")
+    logger.debug(f"flush: chunk rows={remaining} cols={len(schema_cols or [])} limit={self.max_rows}")
     if st["open"]:
       tmp = os.path.join(self.tmpdir, f"open_{uuid.uuid4().hex}.parquet")
       try:
@@ -768,7 +778,7 @@ class ChunkState:
           st["rows"] += take
           remaining -= take
           start += take
-          logger.info(f"flush: appended chunk idx={st['next']} +{take} -> {st['rows']}")
+          logger.debug(f"flush: appended chunk idx={st['next']} +{take} -> {st['rows']}")
         if st["rows"] >= self.max_rows:
           st["next"] += 1
           st["open"] = None
@@ -786,12 +796,12 @@ class ChunkState:
       if take < self.max_rows:
         st["open"] = os_key
         st["rows"] = take
-        logger.info(f"flush: new open chunk idx={st['next']} rows={take}")
+        logger.debug(f"flush: new open chunk idx={st['next']} rows={take}")
       else:
         st["next"] += 1
         st["open"] = None
         st["rows"] = 0
-        logger.info(f"flush: full chunk idx={st['next'] - 1} rows={take}")
+        logger.debug(f"flush: full chunk idx={st['next'] - 1} rows={take}")
       remaining -= take
       start += take
 
@@ -1035,6 +1045,7 @@ class _BaseTransfer:
     self.tranches = get_base(model_id, model_version)
     self.collection = get_coll(self.model_id, self.model_version)
     self.store = MinioStore()
+    self.store.require_bucket(self.bucket)
     self.tmpdir = make_temp("isaura_xfer_")
     self.tmpdir_sinkw = make_temp("isaura_sinkw_")
     bind_temp_dirs(self, self.tmpdir, self.tmpdir_sinkw)
@@ -1151,20 +1162,20 @@ class _BaseTransfer:
         DataFrames of matching rows.
     """
     n = len(wanted) if hasattr(wanted, "__len__") else None
-    logger.info(
+    logger.debug(
       f"[select_rows_batched] starting n={n} input_col={input_col} batch_size={batch_size} bucket={self.bucket}"
     )
     source = None
     try:
       if n is not None and n >= STREAM_PARQUET_THRESHOLD:
         prefix = hive_prefix(self.tranches) + "/"
-        logger.info(f"[select_rows_batched] streaming mode n={n} bucket={self.bucket} prefix={prefix}")
+        logger.debug(f"[select_rows_batched] streaming mode n={n} bucket={self.bucket} prefix={prefix}")
         source = stream_parquet_filtered(
           self.store, self.bucket, prefix, wanted, header=input_col, batch_size=batch_size
         )
       else:
         files = list_parquet_keys(self.store, self.bucket, self.tranches)
-        logger.info(
+        logger.debug(
           f"[select_rows_batched] duckdb mode n={n} bucket={self.bucket} files={(len(files) if isinstance(files, list) else files)}"
         )
         source = query_batched(
@@ -1354,7 +1365,7 @@ class _BaseTransfer:
       del df
       if n_batches % 20 == 0:
         gc.collect()
-        logger.info(
+        logger.debug(
           f"[copy] batch={n_batches} priv={tp} pub={tu} elapsed={time.time() - t0:.1f}s rss={rss_mb():.0f}MB"
         )
     if w_priv:
@@ -1373,7 +1384,7 @@ class _BaseTransfer:
     gc.collect()
     elapsed = time.time() - t0
     rate = total / elapsed if elapsed > 0 else 0
-    logger.success(
+    logger.debug(
       f"[copy] done priv={tp} pub={tu} total={total} elapsed={elapsed:.1f}s rate={rate:.0f}/s rss={rss_mb():.0f}MB"
     )
     return (tp, tu)

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -150,14 +150,18 @@ def read(input_file, project_name, model, version, output_file, approximate):
   with IsauraReader(
     model_id=model, model_version=version, bucket=project_name, input_csv=input_file, approximate=approximate
   ) as r:
-    for _ in r.read_batched(output_csv=output_file):
-      pass
+    total = sum(len(chunk) for chunk in r.read_batched(output_csv=output_file))
+  dest = f" → {output_file}" if output_file else ""
+  logger.info(f"Done — {total} rows{dest}")
 
 
 @cli.command("pull")
 @apply_opts(opt_input_file, opt_project, opt_model, opt_version)
-def pull(input_file, project_name, model, version):
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
+def pull(input_file, project_name, model, version, verbose):
   """Pull model outputs from the cloud store to local."""
+  if verbose:
+    logger.set_verbosity(True)
   pn = project_name or DEFAULT_BUCKET_NAME
   with IsauraPull(model_id=model, model_version=version, bucket=pn, input_csv=input_file) as pl:
     pl.pull()

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -257,14 +257,50 @@ def cmd_inspect(what, model, version, project_name, access, input_file, output_f
 
 
 @cli.command("catalog")
-@apply_opts(opt_project, opt_cloud)
+@click.option("--remote", "-r", "cloud", is_flag=True, default=False,
+              help="List models in the remote store instead of local")
+@click.option("--project-name", "-pn", required=False, default=None,
+              help="Project (bucket) name — e.g. isaura-public or isaura-private")
 def cmd_inspect_models(project_name, cloud):
   """List all models stored in a project bucket."""
+  if not project_name:
+    if cloud:
+      console.print(
+        "[yellow]Please specify a project name.[/] "
+        "Use [bold]-pn isaura-public[/bold] or [bold]-pn isaura-private[/bold]."
+      )
+    else:
+      console.print(
+        "[yellow]Please specify a project name.[/] "
+        "Run [bold]isaura info[/bold] to see available local projects, "
+        "then re-run with [bold]-pn <project>[/bold]."
+      )
+    return
+  if cloud:
+    from isaura.const import MINIO_CLOUD_AK
+    if not MINIO_CLOUD_AK:
+      console.print(
+        "[yellow]No remote credentials configured.[/] "
+        "Run [bold]isaura configure --remote[/bold] first."
+      )
+      return
   insp = IsauraInspect(cloud=cloud)
-  # warm up the client so the health-check log fires before the spinner
   insp._clients(project_name)
-  with console.status("Fetching catalog...", spinner="dots"):
-    rows = insp.inspect_models(project_name, prefix_filter="")
+  try:
+    with console.status("Fetching catalog...", spinner="dots"):
+      rows = insp.inspect_models(project_name, prefix_filter="")
+  except Exception as e:
+    msg = str(e)
+    if "NoSuchBucket" in msg or "does not exist" in msg.lower():
+      console.print(f"[red]Project [bold]{project_name}[/bold] not found.[/] Run [bold]isaura info{'  --remote' if cloud else ''}[/bold] to see available projects.")
+    elif "InvalidAccessKeyId" in msg or "SignatureDoesNotMatch" in msg or "Access Key" in msg:
+      console.print("[red]Invalid credentials.[/] Run [bold]isaura configure --remote[/bold] to update them.")
+    elif "connect" in msg.lower() or "endpoint" in msg.lower():
+      target = "remote store" if cloud else "local MinIO"
+      console.print(f"[red]Could not connect to {target}.[/]" + ("" if cloud else " Is Docker running? Try [bold]isaura engine --start[/bold]."))
+    else:
+      console.print(f"[red]Catalog fetch failed:[/] {msg}")
+    return
   if not rows:
     console.print(f"[yellow]No models found in {project_name}[/]")
     return

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -4,7 +4,7 @@ import rich_click.rich_click as rc
 from isaura.manage import (
   IsauraMover,
   IsauraCopy,
-  IsauraRemover,
+  IsauraMolRemover,
   IsauraWriter,
   IsauraReader,
   IsauraInspect,
@@ -54,15 +54,15 @@ def cli():
 
 
 show_figlet()
-opt_model = click.option("--model", "-m", required=True, help="Ersilia model id (eosxxxx)")
-opt_model_opt = click.option("--model", "-m", required=False, default=None, help="Ersilia model id (eosxxxx)")
+opt_model = click.option("--model-id", "-m", "model", required=True, help="Ersilia model id (eosxxxx)")
+opt_model_opt = click.option("--model-id", "-m", "model", required=False, default=None, help="Ersilia model id (eosxxxx)")
 opt_version = click.option("--version", "-v", default="v1", show_default=True, help="Model version")
 opt_project = click.option(
   "--project-name", "-pn", required=False, default=None, help="Project (bucket) name"
 )
 opt_project_req = click.option("--project-name", "-pn", required=True, help="Project (bucket) name")
-opt_input_file = click.option("--input-file", "-i", required=True, help="Path to input CSV")
-opt_ins_input_file = click.option("--input-file", "-i", required=False, help="Path to input CSV")
+opt_input_file = click.option("--input", "-i", "input_file", required=True, help="Path to input CSV")
+opt_ins_input_file = click.option("--input", "-i", "input_file", required=False, help="Path to input CSV")
 opt_output_file = click.option(
   "--output-file", "-o", required=False, default=None, help="Path to output file (csv/h5)"
 )
@@ -123,28 +123,54 @@ def configure(remote, do_update, show_secrets, test_creds):
     configure_show(reveal=show_secrets)
 
 
-@cli.command("write")
-@apply_opts(opt_input_file, opt_project, opt_access, opt_model, opt_version, opt_force_flag)
-def write(input_file, project_name, access, model, version, force):
-  """Store model outputs in a project bucket."""
-  if project_name in (DEFAULT_PRIVATE_BUCKET_NAME, DEFAULT_BUCKET_NAME):
-    if not force:
-      logger.error("Access denied to write to default project names. Re-run with --force to allow it.")
-      sys.exit(1)
-    logger.warning(f"Force-enabled write directly to protected bucket: {project_name}")
-  if project_name is None:
-    logger.error("Please specify the project name in order to write the data!")
+@cli.command("create")
+@click.option("--project-name", "-pn", required=True, help="Name for the new project bucket")
+@click.option("--access", type=click.Choice(["public", "private"]), required=True, help="Access level for molecules stored in this bucket")
+def create(project_name, access):
+  """Create a new local project bucket."""
+  import re
+  import json
+  import tempfile
+  from isaura.base import MinioStore
+  from isaura.const import (
+    MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK,
+    DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME, ACCESS_FILE,
+  )
+  if not re.fullmatch(r"[a-zA-Z0-9-]+", project_name):
+    console.print("[red]Invalid project name.[/] Only alphanumeric characters and [bold]-[/bold] are allowed.")
     sys.exit(1)
+  if project_name in (DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME):
+    console.print(f"[red]The name [bold]{project_name}[/bold] is reserved and cannot be used.[/]")
+    sys.exit(1)
+  store = MinioStore(endpoint=MINIO_ENDPOINT, access=MINIO_LOCAL_AK, secret=MINIO_LOCAL_SK)
+  store.ensure_bucket(project_name)
+  with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+    json.dump({"access": access}, f)
+    tmp_path = f.name
+  store.upload_file(tmp_path, project_name, ACCESS_FILE)
+  console.print(f"[green]Project [bold]{project_name}[/bold] created with access=[bold]{access}[/bold].[/]")
+
+
+@cli.command("write")
+@apply_opts(opt_input_file, opt_project_req, opt_model, opt_version)
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
+def write(input_file, project_name, model, version, verbose):
+  """Store model outputs in a project bucket."""
+  if verbose:
+    logger.set_verbosity(True)
   with IsauraWriter(
-    input_csv=input_file, model_id=model, model_version=version, bucket=project_name, access=access
+    input_csv=input_file, model_id=model, model_version=version, bucket=project_name
   ) as w:
     w.write()
 
 
 @cli.command("read")
 @apply_opts(opt_input_file, opt_project, opt_model, opt_version, opt_output_file, opt_approx)
-def read(input_file, project_name, model, version, output_file, approximate):
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
+def read(input_file, project_name, model, version, output_file, approximate, verbose):
   """Retrieve stored model outputs for a set of inputs."""
+  if verbose:
+    logger.set_verbosity(True)
   if approximate:
     logger.warning("Approximate Nearest Neighbor search is under active development and may return incomplete or unexpected results.")
   with IsauraReader(
@@ -152,7 +178,7 @@ def read(input_file, project_name, model, version, output_file, approximate):
   ) as r:
     total = sum(len(chunk) for chunk in r.read_batched(output_csv=output_file))
   dest = f" → {output_file}" if output_file else ""
-  logger.info(f"Done — {total} rows{dest}")
+  console.print(f"[green]✓[/green] [bold]{model}/{version}[/bold]: [bold]{total}[/bold] rows{dest}")
 
 
 @cli.command("pull")
@@ -169,31 +195,40 @@ def pull(input_file, project_name, model, version, verbose):
 
 @cli.command("push")
 @apply_opts(opt_project, opt_model, opt_version)
-def push(project_name, model, version):
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
+def push(project_name, model, version, verbose):
   """Push local model outputs to the cloud store."""
+  if verbose:
+    logger.set_verbosity(True)
   p = IsauraPush(model, version, project_name)
   p.push()
 
 
 @cli.command("copy")
 @apply_opts(opt_model, opt_version, opt_project_req, opt_dump_outdir)
-def cp(model, version, project_name, output_dir):
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
+def cp(model, version, project_name, output_dir, verbose):
   """Copy model outputs from a project bucket into the canonical isaura-public/private buckets."""
+  if verbose:
+    logger.set_verbosity(True)
   with IsauraCopy(model_id=model, model_version=version, bucket=project_name, output_dir=output_dir) as c:
-    if output_dir is None:
-      priv, pub = c.copy()
-      logger.info(f"Copied private_new={priv} public_new={pub} from {project_name}")
-    else:
-      c.copy()
+    priv, pub = c.copy()
+  if output_dir is None:
+    parts = []
+    if pub:
+      parts.append(f"[bold]{pub}[/bold] → isaura-public")
+    if priv:
+      parts.append(f"[bold]{priv}[/bold] → isaura-private")
+    console.print(f"[green]✓[/green] [bold]{model}/{version}[/bold] copied: {', '.join(parts) if parts else 'nothing new'}")
 
 
-@cli.command("move")
-@apply_opts(opt_model, opt_version, opt_project_req)
-def mv(model, version, project_name):
-  """Move model outputs into the canonical isaura-public/private buckets (removes source)."""
-  with IsauraMover(model_id=model, model_version=version, bucket=project_name) as m:
-    m.move()
-    logger.info(f"Move done for {model}/{version} from {project_name}")
+# @cli.command("move")
+# @apply_opts(opt_model, opt_version, opt_project_req)
+# def mv(model, version, project_name):
+#   """Move model outputs into the canonical isaura-public/private buckets (removes source)."""
+#   with IsauraMover(model_id=model, model_version=version, bucket=project_name) as m:
+#     m.move()
+#     logger.info(f"Move done for {model}/{version} from {project_name}")
 
 
 @cli.command("engine")
@@ -218,44 +253,87 @@ def engine(start, stop, status):
 
 
 @cli.command("remove")
-@apply_opts(opt_model_opt, opt_version, opt_project_req, opt_yes_flag)
-def rm(model, version, project_name, yes):
-  """Delete model outputs from a bucket. Requires --yes to confirm."""
+@click.option("--model-id", "-m", "model", required=True, help="Ersilia model ID (eosxxxx)")
+@click.option("--version", "-v", default="v1", show_default=True, help="Model version")
+@click.option("--project-name", "-pn", required=True, help="Project (bucket) name")
+@click.option("--input", "-i", "input_file", required=True, help="CSV of molecules to remove")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmation prompt")
+def rm(model, version, project_name, input_file, verbose, yes):
+  """Remove specific molecules from a project bucket."""
+  if verbose:
+    logger.set_verbosity(True)
   if not yes:
-    logger.info("Add --yes to confirm deletion")
+    console.print(
+      f"[yellow]Warning:[/yellow] This will permanently remove molecules from "
+      f"[bold]{model}/{version}[/bold] in [bold]{project_name}[/bold] and cannot be undone."
+    )
+    if not click.confirm("Proceed?", default=False):
+      console.print("[dim]Cancelled.[/dim]")
+      return
+  with IsauraMolRemover(
+    model_id=model, model_version=version, bucket=project_name, input_csv=input_file
+  ) as r:
+    n_removed, n_not_found = r.remove()
+  not_found_str = f", [yellow]{n_not_found} not found[/yellow]" if n_not_found else ""
+  console.print(
+    f"[green]✓[/green] [bold]{model}/{version}[/bold] → [bold]{project_name}[/bold]: "
+    f"[bold]{n_removed}[/bold] molecules removed{not_found_str}"
+  )
+
+
+@cli.command("destroy")
+@click.option("--project-name", "-pn", required=True, help="Project (bucket) name to destroy")
+@click.option("--model-id", "-m", "model", required=False, default=None, help="If set, destroy only this model's data")
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmation prompt")
+def destroy(project_name, model, yes):
+  """Destroy a project bucket or a model's data within it. Local only — cannot target isaura-public or isaura-private."""
+  from isaura.base import MinioStore
+  from isaura.const import MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK
+  if project_name in (DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME):
+    console.print(f"[red][bold]{project_name}[/bold] is a reserved bucket and cannot be destroyed.[/]")
     sys.exit(1)
+  store = MinioStore(endpoint=MINIO_ENDPOINT, access=MINIO_LOCAL_AK, secret=MINIO_LOCAL_SK)
+  store.require_bucket(project_name)
+  if not yes:
+    if model:
+      console.print(
+        f"[yellow]Warning:[/yellow] This will permanently delete all data for "
+        f"[bold]{model}[/bold] in [bold]{project_name}[/bold] and cannot be undone."
+      )
+    else:
+      console.print(
+        f"[yellow]Warning:[/yellow] This will permanently destroy the entire project "
+        f"[bold]{project_name}[/bold] and all its data and cannot be undone."
+      )
+    if not click.confirm("Proceed?", default=False):
+      console.print("[dim]Cancelled.[/dim]")
+      return
   if model:
-    with IsauraRemover(model_id=model, model_version=version, bucket=project_name) as r:
-      r.remove()
-    logger.info(f"Remove done for {model}/{version} in {project_name}")
+    with console.status(f"Deleting {model} from {project_name}...", spinner="dots"):
+      n = store.delete_prefix(project_name, f"{model}/")
+    console.print(f"[green]✓[/green] [bold]{model}[/bold] deleted from [bold]{project_name}[/bold]: {n} objects removed")
   else:
-    with IsauraRemover(project_name=project_name) as r:
-      r.remove()
-    logger.info(f"Remove done for all data in {project_name}")
+    with console.status(f"Destroying {project_name}...", spinner="dots"):
+      n = store.delete_prefix(project_name, "")
+      store.client.delete_bucket(Bucket=project_name)
+    console.print(f"[green]✓[/green] Project [bold]{project_name}[/bold] destroyed: {n} objects removed")
 
 
 @cli.command("inspect")
-@click.option("--model_id", "-m", required=True, help="Ersilia model ID to inspect (e.g. eos4e40)")
+@click.option("--model-id", "-m", "model_id", required=True, help="Ersilia model ID to inspect (e.g. eos4e40)")
 @click.option("--version", "-v", default="v1", show_default=True, help="Model version")
-@click.option("--project-name", "-pn", required=False, default=None,
-              help="Restrict search to this project bucket. If omitted, --access is used to select buckets.")
-@click.option("--access", type=click.Choice(["both", "public", "private"]), default=None, required=True,
-              help="Which bucket scope to search: public, private, or both. Ignored when --project-name is set.")
-@click.option("--input", "-i", "input_file", required=True,
-              help="CSV of molecules to check against the store.")
+@click.option("--project-name", "-pn", required=True, help="Project bucket to search (e.g. isaura-public, isaura-private).")
+@click.option("--input", "-i", "input_file", required=False, default=None,
+              help="CSV of molecules to check against the store. If omitted, all stored molecules are returned.")
 @click.option("--output", "-o", "output_file", required=True,
-              help="Path to write the results CSV. Each row in the input is annotated with whether it is stored.")
+              help="Path to write the results CSV.")
 @click.option("--remote", "-r", "cloud", is_flag=True, default=False,
               help="Query the remote (cloud) store. Default: local MinIO instance.")
-def cmd_inspect(model_id, version, project_name, access, input_file, output_file, cloud):
-  """Check which molecules from an input CSV are already stored for a model.
-
-  Reads the molecules in --input, queries the store, and writes a results CSV
-  to --output annotating each molecule as found or missing. Useful before
-  running a job to avoid re-computing already-cached results.
-  """
+def cmd_inspect(model_id, version, project_name, input_file, output_file, cloud):
+  """Check which molecules from an input CSV are already stored for a model. If no input is given, returns all stored molecules."""
   insp = IsauraInspect(
-    model_id=model_id, model_version=version, project_name=project_name, access=access, cloud=cloud
+    model_id=model_id, model_version=version, project_name=project_name, cloud=cloud
   )
   if cloud:
     for b in insp.buckets():
@@ -264,7 +342,10 @@ def cmd_inspect(model_id, version, project_name, access, input_file, output_file
   else:
     ctx = contextlib.nullcontext()
   with ctx:
-    df = insp.inspect_inputs(input_file, output_file)
+    if input_file:
+      df = insp.inspect_inputs(input_file, output_file)
+    else:
+      df = insp.list_available(output_file)
   logger.info(f"wrote {len(df)} rows → {output_file}")
 
 
@@ -349,10 +430,15 @@ def info(cloud):
   if not buckets:
     console.print(f"[yellow]No projects found in {title.lower()}.[/]")
     return
-  rows = [{"name": b["Name"], "created": b["CreationDate"].strftime("%Y-%m-%d %H:%M")} for b in buckets]
+  def _location(bucket_name):
+    if cloud:
+      return f"{endpoint}/{bucket_name}"
+    return os.path.expanduser(f"~/minio-data/{bucket_name}")
+  rows = [{"name": b["Name"], "created": b["CreationDate"].strftime("%Y-%m-%d %H:%M"), "location": _location(b["Name"])} for b in buckets]
   table = make_table(title, [
     {"key": "name", "name": "Project", "justify": "left", "style": "bold"},
     {"key": "created", "name": "Created", "justify": "left"},
+    {"key": "location", "name": "URL" if cloud else "Path", "justify": "left", "style": "dim"},
   ], rows)
   console.print(table)
 
@@ -368,17 +454,7 @@ def info(cloud):
 @click.option("--isaura-dir", "-d", required=False, default=".", hidden=True,
               help="Path to an isaura folder (used mainly to resolve output defaults).")
 def cmd_stats(project_name, cloud, output_dir, isaura_dir):
-  """Generate a JSON inventory of all models stored in a project bucket.
-
-  Walks the bucket, counts stored molecules and chunk files per model, and
-  writes a timestamped JSON report to --output-dir. Useful for auditing storage
-  usage before or after a bulk write, copy, or move operation.
-
-  \b
-  Example:
-    isaura stats -pn isaura-public -o ./reports
-    isaura stats -pn ersilia-hiv --remote -o ./reports
-  """
+  """Generate a JSON inventory of all models stored in a project bucket."""
   ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
   out_path = os.path.join(output_dir, f"isaura_stats_{ts}.json")
   st = IsauraStat(project_name=project_name, cloud=cloud, endpoint=None)

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -22,6 +22,7 @@ from isaura.helpers import (
   make_table,
   show_figlet,
   run_docker_compose,
+  get_engine_status,
   spinner,
 )
 
@@ -87,16 +88,10 @@ opt_approx = click.option(
   default=False,
   help="Use Approximate Nearest Neighbor search for result retrieval. [red bold]Under development — may return incomplete or unexpected results.[/]",
 )
-opt_cloud = click.option(
-  "--cloud", "-c", is_flag=True, default=False, help="Specifies to use isaura in cloud mode or not."
-)
-opt_start = click.option(
-  "--start",
-  "-s",
-  is_flag=True,
-  default=False,
-  help="Specifies to start isuara main engines such as minio, milvus, nns server.",
-)
+opt_cloud = click.option("--remote", "-r", "cloud", is_flag=True, default=False, help="Use the remote store instead of local")
+opt_start = click.option("--start", "-s", is_flag=True, default=False, help="Start local services (MinIO)")
+opt_stop = click.option("--stop", is_flag=True, default=False, help="Stop local services")
+opt_status = click.option("--status", is_flag=True, default=False, help="Show status of local services")
 opt_isaura_dir = click.option(
   "--isaura-dir",
   "-d",
@@ -110,9 +105,28 @@ opt_stats_outdir = click.option(
 )
 
 
+@cli.command("configure")
+@click.option("--remote", is_flag=True, default=False, help="Add or update remote/cloud credentials")
+@click.option("--update", "do_update", is_flag=True, default=False, help="Update an existing credential interactively")
+@click.option("--show-secrets", is_flag=True, default=False, help="Show all credential values unmasked")
+@click.option("--test-credentials", "test_creds", is_flag=True, default=False, help="Test local and cloud credential connectivity")
+def configure(remote, do_update, show_secrets, test_creds):
+  """Show or update isaura configuration."""
+  from isaura.configure import configure_show, configure_remote_interactive, configure_update_interactive, configure_test_credentials
+  if test_creds:
+    configure_test_credentials()
+  elif do_update:
+    configure_update_interactive()
+  elif remote:
+    configure_remote_interactive()
+  else:
+    configure_show(reveal=show_secrets)
+
+
 @cli.command("write")
 @apply_opts(opt_input_file, opt_project, opt_access, opt_model, opt_version, opt_force_flag)
 def write(input_file, project_name, access, model, version, force):
+  """Store model outputs in a project bucket."""
   if project_name in (DEFAULT_PRIVATE_BUCKET_NAME, DEFAULT_BUCKET_NAME):
     if not force:
       logger.error("Access denied to write to default project names. Re-run with --force to allow it.")
@@ -130,6 +144,7 @@ def write(input_file, project_name, access, model, version, force):
 @cli.command("read")
 @apply_opts(opt_input_file, opt_project, opt_model, opt_version, opt_output_file, opt_approx)
 def read(input_file, project_name, model, version, output_file, approximate):
+  """Retrieve stored model outputs for a set of inputs."""
   if approximate:
     logger.warning("Approximate Nearest Neighbor search is under active development and may return incomplete or unexpected results.")
   with IsauraReader(
@@ -142,6 +157,7 @@ def read(input_file, project_name, model, version, output_file, approximate):
 @cli.command("pull")
 @apply_opts(opt_input_file, opt_project, opt_model, opt_version)
 def pull(input_file, project_name, model, version):
+  """Pull model outputs from the cloud store to local."""
   pn = project_name or DEFAULT_BUCKET_NAME
   with IsauraPull(model_id=model, model_version=version, bucket=pn, input_csv=input_file) as pl:
     pl.pull()
@@ -150,6 +166,7 @@ def pull(input_file, project_name, model, version):
 @cli.command("push")
 @apply_opts(opt_project, opt_model, opt_version)
 def push(project_name, model, version):
+  """Push local model outputs to the cloud store."""
   p = IsauraPush(model, version, project_name)
   p.push()
 
@@ -157,6 +174,7 @@ def push(project_name, model, version):
 @cli.command("copy")
 @apply_opts(opt_model, opt_version, opt_project_req, opt_dump_outdir)
 def cp(model, version, project_name, output_dir):
+  """Copy model outputs from a project bucket into the canonical isaura-public/private buckets."""
   with IsauraCopy(model_id=model, model_version=version, bucket=project_name, output_dir=output_dir) as c:
     if output_dir is None:
       priv, pub = c.copy()
@@ -168,20 +186,37 @@ def cp(model, version, project_name, output_dir):
 @cli.command("move")
 @apply_opts(opt_model, opt_version, opt_project_req)
 def mv(model, version, project_name):
+  """Move model outputs into the canonical isaura-public/private buckets (removes source)."""
   with IsauraMover(model_id=model, model_version=version, bucket=project_name) as m:
     m.move()
     logger.info(f"Move done for {model}/{version} from {project_name}")
 
 
 @cli.command("engine")
-@apply_opts(opt_start)
-def engine(start):
-  s = spinner("Starting the engines. Please wait!", run_docker_compose, start)
+@apply_opts(opt_start, opt_stop, opt_status)
+def engine(start, stop, status):
+  """Manage local isaura services (MinIO). Use --start, --stop, or --status."""
+  if stop:
+    run_docker_compose(up=False)
+  elif start:
+    run_docker_compose(up=True)
+  else:
+    info = get_engine_status()
+    table = make_table("Local services", [
+      {"key": "name", "name": "Service", "justify": "left", "style": "bold"},
+      {"key": "status", "name": "Status", "justify": "left"},
+    ], [{"name": "Docker", "status": "[green]running[/]" if info["docker"] else "[red]not running[/]"}] + [
+      {"name": c["name"], "status": c["status"]} for c in info["containers"]
+    ])
+    console.print(table)
+    if not info["docker"]:
+      console.print("[dim]Open Docker Desktop and run [bold]isaura engine --start[/bold] to start local services.[/]")
 
 
 @cli.command("remove")
 @apply_opts(opt_model_opt, opt_version, opt_project_req, opt_yes_flag)
 def rm(model, version, project_name, yes):
+  """Delete model outputs from a bucket. Requires --yes to confirm."""
   if not yes:
     logger.info("Add --yes to confirm deletion")
     sys.exit(1)
@@ -199,6 +234,7 @@ def rm(model, version, project_name, yes):
 @apply_opts(opt_model, opt_version, opt_project, opt_access, opt_ins_input_file, opt_output_file, opt_cloud)
 @click.argument("what", type=click.Choice(["inputs"]), required=False, default="inputs")
 def cmd_inspect(what, model, version, project_name, access, input_file, output_file, cloud):
+  """List available inputs or entries for a model in the store."""
   insp = IsauraInspect(
     model_id=model, model_version=version, project_name=project_name, access=access, cloud=cloud
   )
@@ -219,6 +255,7 @@ def cmd_inspect(what, model, version, project_name, access, input_file, output_f
 @cli.command("catalog")
 @apply_opts(opt_project, opt_cloud)
 def cmd_inspect_models(project_name, cloud):
+  """List all models stored in a project bucket."""
   insp = IsauraInspect(cloud=cloud)
   # warm up the client so the health-check log fires before the spinner
   insp._clients(project_name)
@@ -232,9 +269,46 @@ def cmd_inspect_models(project_name, cloud):
   console.print(table)
 
 
+@cli.command("info")
+@click.option("--remote", "-r", "cloud", is_flag=True, default=False, help="List projects in the remote store instead of local")
+def info(cloud):
+  """List available projects (buckets) in the local or remote store."""
+  from isaura.base import MinioStore
+  from isaura.const import (
+    MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK,
+    MINIO_ENDPOINT_CLOUD, MINIO_CLOUD_AK, MINIO_CLOUD_SK,
+  )
+  if cloud:
+    if not MINIO_CLOUD_AK:
+      console.print("[yellow]No cloud credentials configured.[/] Run [bold]isaura configure --remote[/bold] first.")
+      return
+    endpoint, access, secret = MINIO_ENDPOINT_CLOUD, MINIO_CLOUD_AK, MINIO_CLOUD_SK
+    title = "Remote projects"
+  else:
+    endpoint, access, secret = MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK
+    title = "Local projects"
+  try:
+    store = MinioStore(endpoint=endpoint, access=access, secret=secret)
+  except SystemExit:
+    target = "remote store" if cloud else "local MinIO"
+    console.print(f"[red]Could not connect to {target}.[/]" + ("" if cloud else " Is Docker running? Try [bold]isaura engine --start[/bold]."))
+    return
+  buckets = store.client.list_buckets().get("Buckets", [])
+  if not buckets:
+    console.print(f"[yellow]No projects found in {title.lower()}.[/]")
+    return
+  rows = [{"name": b["Name"], "created": b["CreationDate"].strftime("%Y-%m-%d %H:%M")} for b in buckets]
+  table = make_table(title, [
+    {"key": "name", "name": "Project", "justify": "left", "style": "bold"},
+    {"key": "created", "name": "Created", "justify": "left"},
+  ], rows)
+  console.print(table)
+
+
 @cli.command("stats")
 @apply_opts(opt_project, opt_access, opt_cloud, opt_stats_outdir, opt_isaura_dir)
 def cmd_stats(project_name, access, cloud, output_dir, isaura_dir):
+  """Generate a JSON inventory of all stored models and their sizes."""
   ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
   out_path = os.path.join(output_dir, f"isaura_stats_{ts}.json")
   st = IsauraStat(project_name=project_name, access=access, cloud=cloud, endpoint=None)

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -2,7 +2,6 @@ import contextlib, datetime, os, sys
 import rich_click as click
 import rich_click.rich_click as rc
 from isaura.manage import (
-  IsauraMover,
   IsauraCopy,
   IsauraMolRemover,
   IsauraWriter,
@@ -23,7 +22,6 @@ from isaura.helpers import (
   show_figlet,
   run_docker_compose,
   get_engine_status,
-  spinner,
 )
 
 click.rich_click.USE_RICH_MARKUP = True
@@ -48,6 +46,34 @@ def apply_opts(*opts):
   return _wrap
 
 
+def _check_model_filename(model_id, filepath):
+  """Warn if a model ID found in the filename doesn't match model_id."""
+  import re
+  if not filepath:
+    return
+  basename = os.path.basename(filepath)
+  found = re.findall(r'eos[a-z0-9]{4}', basename.lower())
+  for match in found:
+    if match != model_id.lower():
+      console.print(
+        f"[red]Filename and --model-id do not match:[/] "
+        f"[bold]{match}[/bold] (filename) vs [bold]{model_id}[/bold] (--model-id)."
+      )
+      sys.exit(1)
+
+
+def _resolve_version(model_id, bucket, store):
+  """Return the latest version stored for a model in a bucket, or 'v1' as fallback."""
+  try:
+    keys = [obj["Key"] for obj in store.list_keys(bucket, f"{model_id}/")]
+    versions = {k.split("/")[1] for k in keys if len(k.split("/")) >= 2 and k.split("/")[1].startswith("v")}
+    if not versions:
+      return "v1"
+    return max(versions, key=lambda v: int(v[1:]) if v[1:].isdigit() else 0)
+  except Exception:
+    return "v1"
+
+
 @click.group()
 def cli():
   pass
@@ -64,7 +90,7 @@ opt_project_req = click.option("--project-name", "-pn", required=True, help="Pro
 opt_input_file = click.option("--input", "-i", "input_file", required=True, help="Path to input CSV")
 opt_ins_input_file = click.option("--input", "-i", "input_file", required=False, help="Path to input CSV")
 opt_output_file = click.option(
-  "--output-file", "-o", required=False, default=None, help="Path to output file (csv/h5)"
+  "--output", "-o", "output_file", required=False, default=None, help="Path to output file (csv/h5)"
 )
 opt_access = click.option(
   "--access",
@@ -158,6 +184,7 @@ def write(input_file, project_name, model, version, verbose):
   """Store model outputs in a project bucket."""
   if verbose:
     logger.set_verbosity(True)
+  _check_model_filename(model, input_file)
   with IsauraWriter(
     input_csv=input_file, model_id=model, model_version=version, bucket=project_name
   ) as w:
@@ -165,16 +192,27 @@ def write(input_file, project_name, model, version, verbose):
 
 
 @cli.command("read")
-@apply_opts(opt_input_file, opt_project, opt_model, opt_version, opt_output_file, opt_approx)
+@apply_opts(opt_input_file, opt_project_req, opt_model, opt_output_file)
+@click.option("--version", "-v", required=False, default=None, help="Model version (default: latest stored version)")
+# @apply_opts(opt_approx)  # approximate search disabled — under development
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
-def read(input_file, project_name, model, version, output_file, approximate, verbose):
+def read(input_file, project_name, model, output_file, version, verbose):
   """Retrieve stored model outputs for a set of inputs."""
   if verbose:
     logger.set_verbosity(True)
-  if approximate:
-    logger.warning("Approximate Nearest Neighbor search is under active development and may return incomplete or unexpected results.")
+  _check_model_filename(model, output_file)
+  if version is None:
+    from isaura.base import MinioStore
+    from isaura.const import MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK
+    try:
+      _store = MinioStore(endpoint=MINIO_ENDPOINT, access=MINIO_LOCAL_AK, secret=MINIO_LOCAL_SK)
+      version = _resolve_version(model, project_name, _store)
+      console.print(f"[dim]No version specified — using latest: {version}[/dim]")
+    except Exception:
+      version = "v1"
+  # approximate = False  # disabled — uncomment opt_approx above to re-enable
   with IsauraReader(
-    model_id=model, model_version=version, bucket=project_name, input_csv=input_file, approximate=approximate
+    model_id=model, model_version=version, bucket=project_name, input_csv=input_file, approximate=False
   ) as r:
     total = sum(len(chunk) for chunk in r.read_batched(output_csv=output_file))
   dest = f" → {output_file}" if output_file else ""
@@ -182,13 +220,23 @@ def read(input_file, project_name, model, version, output_file, approximate, ver
 
 
 @cli.command("pull")
-@apply_opts(opt_input_file, opt_project, opt_model, opt_version)
+@apply_opts(opt_input_file, opt_project, opt_model)
+@click.option("--version", "-v", required=False, default=None, help="Model version (default: latest stored version in the remote bucket)")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
 def pull(input_file, project_name, model, version, verbose):
   """Pull model outputs from the cloud store to local."""
   if verbose:
     logger.set_verbosity(True)
   pn = project_name or DEFAULT_BUCKET_NAME
+  if version is None:
+    from isaura.base import MinioStore
+    from isaura.const import MINIO_ENDPOINT_CLOUD, MINIO_CLOUD_AK, MINIO_CLOUD_SK
+    try:
+      _store = MinioStore(endpoint=MINIO_ENDPOINT_CLOUD, access=MINIO_CLOUD_AK, secret=MINIO_CLOUD_SK)
+      version = _resolve_version(model, pn, _store)
+      console.print(f"[dim]No version specified — using latest: {version}[/dim]")
+    except Exception:
+      version = "v1"
   with IsauraPull(model_id=model, model_version=version, bucket=pn, input_csv=input_file) as pl:
     pl.pull()
 
@@ -204,7 +252,7 @@ def push(project_name, model, version, verbose):
   p.push()
 
 
-@cli.command("copy")
+@cli.command("persist")
 @apply_opts(opt_model, opt_version, opt_project_req, opt_dump_outdir)
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Show detailed internal logs")
 def cp(model, version, project_name, output_dir, verbose):
@@ -284,14 +332,25 @@ def rm(model, version, project_name, input_file, verbose, yes):
 
 @cli.command("destroy")
 @click.option("--project-name", "-pn", required=True, help="Project (bucket) name to destroy")
-@click.option("--model-id", "-m", "model", required=False, default=None, help="If set, destroy only this model's data")
+@click.option("--model-id", "-m", "model", required=False, default=None, help="If set, destroy only this model's data. Requires --version.")
+@click.option("--version", "-v", required=False, default=None, show_default=True, help="Model version to destroy. Required when --model-id is set.")
 @click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmation prompt")
-def destroy(project_name, model, yes):
-  """Destroy a project bucket or a model's data within it. Local only — cannot target isaura-public or isaura-private."""
+def destroy(project_name, model, version, yes):
+  """Destroy a project bucket or a specific model version within it.
+
+  \b
+  • Without --model-id: destroys the entire project bucket.
+  • With --model-id and --version: destroys only that model/version combination.
+
+  Cannot target isaura-public or isaura-private.
+  """
+  if model and not version:
+    console.print("[red]--version is required when --model-id is set.[/] Example: [bold]-m eos4e40 -v v1[/bold]")
+    sys.exit(1)
   from isaura.base import MinioStore
   from isaura.const import MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK
-  if project_name in (DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME):
-    console.print(f"[red][bold]{project_name}[/bold] is a reserved bucket and cannot be destroyed.[/]")
+  if not model and project_name in (DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME):
+    console.print(f"[red][bold]{project_name}[/bold] is a reserved bucket and cannot be destroyed.[/] Use [bold]--model-id[/bold] and [bold]--version[/bold] to remove a specific model.")
     sys.exit(1)
   store = MinioStore(endpoint=MINIO_ENDPOINT, access=MINIO_LOCAL_AK, secret=MINIO_LOCAL_SK)
   store.require_bucket(project_name)
@@ -299,7 +358,7 @@ def destroy(project_name, model, yes):
     if model:
       console.print(
         f"[yellow]Warning:[/yellow] This will permanently delete all data for "
-        f"[bold]{model}[/bold] in [bold]{project_name}[/bold] and cannot be undone."
+        f"[bold]{model}/{version}[/bold] in [bold]{project_name}[/bold] and cannot be undone."
       )
     else:
       console.print(
@@ -310,9 +369,9 @@ def destroy(project_name, model, yes):
       console.print("[dim]Cancelled.[/dim]")
       return
   if model:
-    with console.status(f"Deleting {model} from {project_name}...", spinner="dots"):
-      n = store.delete_prefix(project_name, f"{model}/")
-    console.print(f"[green]✓[/green] [bold]{model}[/bold] deleted from [bold]{project_name}[/bold]: {n} objects removed")
+    with console.status(f"Deleting {model}/{version} from {project_name}...", spinner="dots"):
+      n = store.delete_prefix(project_name, f"{model}/{version}/")
+    console.print(f"[green]✓[/green] [bold]{model}/{version}[/bold] deleted from [bold]{project_name}[/bold]: {n} objects removed")
   else:
     with console.status(f"Destroying {project_name}...", spinner="dots"):
       n = store.delete_prefix(project_name, "")
@@ -430,13 +489,35 @@ def info(cloud):
   if not buckets:
     console.print(f"[yellow]No projects found in {title.lower()}.[/]")
     return
+
+  def _access_label(bucket_name):
+    import json, tempfile
+    if "public" in bucket_name:
+      return "[green]public[/green]"
+    if "private" in bucket_name:
+      return "[red]private[/red]"
+    try:
+      tmp = tempfile.mktemp()
+      store.download_file(bucket_name, "access.json", tmp)
+      with open(tmp) as f:
+        val = json.load(f).get("access", "")
+      if val == "public":
+        return "[green]public[/green]"
+      if val == "private":
+        return "[red]private[/red]"
+    except Exception:
+      pass
+    return "[dim]–[/dim]"
+
   def _location(bucket_name):
     if cloud:
       return f"{endpoint}/{bucket_name}"
     return os.path.expanduser(f"~/minio-data/{bucket_name}")
-  rows = [{"name": b["Name"], "created": b["CreationDate"].strftime("%Y-%m-%d %H:%M"), "location": _location(b["Name"])} for b in buckets]
+
+  rows = [{"name": b["Name"], "created": b["CreationDate"].strftime("%Y-%m-%d %H:%M"), "access": _access_label(b["Name"]), "location": _location(b["Name"])} for b in buckets]
   table = make_table(title, [
     {"key": "name", "name": "Project", "justify": "left", "style": "bold"},
+    {"key": "access", "name": "Access", "justify": "left"},
     {"key": "created", "name": "Created", "justify": "left"},
     {"key": "location", "name": "URL" if cloud else "Path", "justify": "left", "style": "dim"},
   ], rows)

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -235,12 +235,27 @@ def rm(model, version, project_name, yes):
 
 
 @cli.command("inspect")
-@apply_opts(opt_model, opt_version, opt_project, opt_access, opt_ins_input_file, opt_output_file, opt_cloud)
-@click.argument("what", type=click.Choice(["inputs"]), required=False, default="inputs")
-def cmd_inspect(what, model, version, project_name, access, input_file, output_file, cloud):
-  """List available inputs or entries for a model in the store."""
+@click.option("--model_id", "-m", required=True, help="Ersilia model ID to inspect (e.g. eos4e40)")
+@click.option("--version", "-v", default="v1", show_default=True, help="Model version")
+@click.option("--project-name", "-pn", required=False, default=None,
+              help="Restrict search to this project bucket. If omitted, --access is used to select buckets.")
+@click.option("--access", type=click.Choice(["both", "public", "private"]), default=None, required=True,
+              help="Which bucket scope to search: public, private, or both. Ignored when --project-name is set.")
+@click.option("--input", "-i", "input_file", required=True,
+              help="CSV of molecules to check against the store.")
+@click.option("--output", "-o", "output_file", required=True,
+              help="Path to write the results CSV. Each row in the input is annotated with whether it is stored.")
+@click.option("--remote", "-r", "cloud", is_flag=True, default=False,
+              help="Query the remote (cloud) store. Default: local MinIO instance.")
+def cmd_inspect(model_id, version, project_name, access, input_file, output_file, cloud):
+  """Check which molecules from an input CSV are already stored for a model.
+
+  Reads the molecules in --input, queries the store, and writes a results CSV
+  to --output annotating each molecule as found or missing. Useful before
+  running a job to avoid re-computing already-cached results.
+  """
   insp = IsauraInspect(
-    model_id=model, model_version=version, project_name=project_name, access=access, cloud=cloud
+    model_id=model_id, model_version=version, project_name=project_name, access=access, cloud=cloud
   )
   if cloud:
     for b in insp.buckets():
@@ -249,11 +264,8 @@ def cmd_inspect(what, model, version, project_name, access, input_file, output_f
   else:
     ctx = contextlib.nullcontext()
   with ctx:
-    if input_file:
-      df = insp.inspect_inputs(input_file, output_file)
-    else:
-      df = insp.list_available(output_file)
-  logger.info(f"wrote {len(df)} rows{(' -> ' + output_file if output_file else '')}")
+    df = insp.inspect_inputs(input_file, output_file)
+  logger.info(f"wrote {len(df)} rows → {output_file}")
 
 
 @cli.command("catalog")
@@ -346,12 +358,30 @@ def info(cloud):
 
 
 @cli.command("stats")
-@apply_opts(opt_project, opt_access, opt_cloud, opt_stats_outdir, opt_isaura_dir)
-def cmd_stats(project_name, access, cloud, output_dir, isaura_dir):
-  """Generate a JSON inventory of all stored models and their sizes."""
+@click.option("--project-name", "-pn", required=True,
+              help="Project (bucket) name to collect statistics for (e.g. isaura-public, isaura-private, or a custom project).")
+@click.option("--remote", "-r", "cloud", is_flag=True, default=False,
+              help="Collect statistics from the remote (cloud) store. Default: local MinIO instance.")
+@click.option("--output-dir", "-o", required=True,
+              help="Folder where the stats JSON file will be written. "
+                   "The file is named isaura_stats_<timestamp>.json.")
+@click.option("--isaura-dir", "-d", required=False, default=".", hidden=True,
+              help="Path to an isaura folder (used mainly to resolve output defaults).")
+def cmd_stats(project_name, cloud, output_dir, isaura_dir):
+  """Generate a JSON inventory of all models stored in a project bucket.
+
+  Walks the bucket, counts stored molecules and chunk files per model, and
+  writes a timestamped JSON report to --output-dir. Useful for auditing storage
+  usage before or after a bulk write, copy, or move operation.
+
+  \b
+  Example:
+    isaura stats -pn isaura-public -o ./reports
+    isaura stats -pn ersilia-hiv --remote -o ./reports
+  """
   ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
   out_path = os.path.join(output_dir, f"isaura_stats_{ts}.json")
-  st = IsauraStat(project_name=project_name, access=access, cloud=cloud, endpoint=None)
+  st = IsauraStat(project_name=project_name, cloud=cloud, endpoint=None)
   written = st.write_json(out_path)
   logger.info(f"isaura stats wrote: {written}")
 

--- a/isaura/cli.py
+++ b/isaura/cli.py
@@ -79,7 +79,8 @@ def cli():
   pass
 
 
-show_figlet()
+if "--help" in sys.argv or "-h" in sys.argv or len(sys.argv) == 1:
+  show_figlet()
 opt_model = click.option("--model-id", "-m", "model", required=True, help="Ersilia model id (eosxxxx)")
 opt_model_opt = click.option("--model-id", "-m", "model", required=False, default=None, help="Ersilia model id (eosxxxx)")
 opt_version = click.option("--version", "-v", default="v1", show_default=True, help="Model version")
@@ -381,16 +382,30 @@ def destroy(project_name, model, version, yes):
 
 @cli.command("inspect")
 @click.option("--model-id", "-m", "model_id", required=True, help="Ersilia model ID to inspect (e.g. eos4e40)")
-@click.option("--version", "-v", default="v1", show_default=True, help="Model version")
+@click.option("--version", "-v", default=None, help="Model version (default: latest stored version)")
 @click.option("--project-name", "-pn", required=True, help="Project bucket to search (e.g. isaura-public, isaura-private).")
-@click.option("--input", "-i", "input_file", required=False, default=None,
-              help="CSV of molecules to check against the store. If omitted, all stored molecules are returned.")
+@click.option("--input", "-i", "input_file", required=True,
+              help="CSV of molecules to check against the store.")
 @click.option("--output", "-o", "output_file", required=True,
               help="Path to write the results CSV.")
 @click.option("--remote", "-r", "cloud", is_flag=True, default=False,
               help="Query the remote (cloud) store. Default: local MinIO instance.")
 def cmd_inspect(model_id, version, project_name, input_file, output_file, cloud):
-  """Check which molecules from an input CSV are already stored for a model. If no input is given, returns all stored molecules."""
+  """Check which molecules from an input CSV are already stored for a model."""
+  from isaura.base import MinioStore
+  if cloud:
+    from isaura.const import MINIO_ENDPOINT_CLOUD, MINIO_CLOUD_AK, MINIO_CLOUD_SK
+    _store = MinioStore(endpoint=MINIO_ENDPOINT_CLOUD, access=MINIO_CLOUD_AK, secret=MINIO_CLOUD_SK)
+  else:
+    from isaura.const import MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK
+    _store = MinioStore(endpoint=MINIO_ENDPOINT, access=MINIO_LOCAL_AK, secret=MINIO_LOCAL_SK)
+  _store.require_bucket(project_name)
+  if version is None:
+    try:
+      version = _resolve_version(model_id, project_name, _store)
+      console.print(f"[dim]No version specified — using latest: {version}[/dim]")
+    except Exception:
+      version = "v1"
   insp = IsauraInspect(
     model_id=model_id, model_version=version, project_name=project_name, cloud=cloud
   )
@@ -401,10 +416,7 @@ def cmd_inspect(model_id, version, project_name, input_file, output_file, cloud)
   else:
     ctx = contextlib.nullcontext()
   with ctx:
-    if input_file:
-      df = insp.inspect_inputs(input_file, output_file)
-    else:
-      df = insp.list_available(output_file)
+    df = insp.inspect_inputs(input_file, output_file)
   logger.info(f"wrote {len(df)} rows → {output_file}")
 
 
@@ -536,6 +548,13 @@ def info(cloud):
               help="Path to an isaura folder (used mainly to resolve output defaults).")
 def cmd_stats(project_name, cloud, output_dir, isaura_dir):
   """Generate a JSON inventory of all models stored in a project bucket."""
+  from isaura.base import MinioStore
+  if cloud:
+    from isaura.const import MINIO_ENDPOINT_CLOUD, MINIO_CLOUD_AK, MINIO_CLOUD_SK
+    MinioStore(endpoint=MINIO_ENDPOINT_CLOUD, access=MINIO_CLOUD_AK, secret=MINIO_CLOUD_SK).require_bucket(project_name)
+  else:
+    from isaura.const import MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK
+    MinioStore(endpoint=MINIO_ENDPOINT, access=MINIO_LOCAL_AK, secret=MINIO_LOCAL_SK).require_bucket(project_name)
   ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
   out_path = os.path.join(output_dir, f"isaura_stats_{ts}.json")
   st = IsauraStat(project_name=project_name, cloud=cloud, endpoint=None)

--- a/isaura/configs/docker-compose.yml
+++ b/isaura/configs/docker-compose.yml
@@ -12,42 +12,46 @@ services:
       - ~/minio-data:/data
     command: server /data --console-address ":9001"
     restart: unless-stopped
-  milvus:
-    image: milvusdb/milvus:v2.4.4
-    container_name: milvus-standalone
-    command: ["milvus", "run", "standalone"]
-    security_opt:
-      - seccomp:unconfined
-    environment:
-      ETCD_USE_EMBED: "true"
-      ETCD_DATA_DIR: /var/lib/milvus/etcd
-      ETCD_CONFIG_PATH: /milvus/configs/embedEtcd.yaml
-      COMMON_STORAGETYPE: local
-      DEPLOY_MODE: STANDALONE
-    volumes:
-      - ~/isaura/volumes/milvus:/var/lib/milvus
-      - ./embedEtcd.yaml:/milvus/configs/embedEtcd.yaml:ro
-      - ./user.yaml:/milvus/configs/user.yaml:ro
-    ports:
-      - "19530:19530"  
-      - "9091:9091"     
-      - "2379:2379"     
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9091/healthz || wget -qO- http://localhost:9091/healthz || exit 1"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-      start_period: 90s
-    restart: unless-stopped
 
-  api:
-    image: ersiliaos/nns:latest
-    container_name: nns-api
-    depends_on:
-      milvus:
-        condition: service_healthy
-    environment:
-      - MILVUS_ADDR=milvus:19530
-    ports:
-      - "8080:8080"
-    restart: unless-stopped
+  # milvus and nns are disabled — not required for current usage.
+  # To re-enable, uncomment the blocks below.
+
+  # milvus:
+  #   image: milvusdb/milvus:v2.4.4
+  #   container_name: milvus-standalone
+  #   command: ["milvus", "run", "standalone"]
+  #   security_opt:
+  #     - seccomp:unconfined
+  #   environment:
+  #     ETCD_USE_EMBED: "true"
+  #     ETCD_DATA_DIR: /var/lib/milvus/etcd
+  #     ETCD_CONFIG_PATH: /milvus/configs/embedEtcd.yaml
+  #     COMMON_STORAGETYPE: local
+  #     DEPLOY_MODE: STANDALONE
+  #   volumes:
+  #     - ~/isaura/volumes/milvus:/var/lib/milvus
+  #     - ./embedEtcd.yaml:/milvus/configs/embedEtcd.yaml:ro
+  #     - ./user.yaml:/milvus/configs/user.yaml:ro
+  #   ports:
+  #     - "19530:19530"
+  #     - "9091:9091"
+  #     - "2379:2379"
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "curl -sf http://localhost:9091/healthz || wget -qO- http://localhost:9091/healthz || exit 1"]
+  #     interval: 30s
+  #     timeout: 20s
+  #     retries: 3
+  #     start_period: 90s
+  #   restart: unless-stopped
+
+  # api:
+  #   image: ersiliaos/nns:latest
+  #   container_name: nns-api
+  #   depends_on:
+  #     milvus:
+  #       condition: service_healthy
+  #   environment:
+  #     - MILVUS_ADDR=milvus:19530
+  #   ports:
+  #     - "8080:8080"
+  #   restart: unless-stopped

--- a/isaura/configure.py
+++ b/isaura/configure.py
@@ -1,0 +1,235 @@
+"""Configuration helpers for the `isaura configure` CLI command."""
+
+import sys
+from pathlib import Path
+
+import click
+import questionary
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from isaura.const import (
+    DEFAULT_BUCKET_NAME,
+    DEFAULT_PRIVATE_BUCKET_NAME,
+    MINIO_ENDPOINT,
+    MINIO_LOCAL_AK,
+    MINIO_LOCAL_SK,
+    MINIO_ENDPOINT_CLOUD,
+    MINIO_CLOUD_AK,
+    MINIO_CLOUD_SK,
+    MINIO_PRIV_CLOUD_AK,
+    MINIO_PRIV_CLOUD_SK,
+)
+
+console = Console()
+
+CONFIG_DIR = Path.home() / ".isaura"
+ENV_PATH = CONFIG_DIR / ".env"
+
+LOCAL_DEFAULTS = {
+    "MINIO_ENDPOINT": "http://127.0.0.1:9000",
+    "NNS_ENDPOINT": "http://127.0.0.1:8080",
+    "DEFAULT_BUCKET_NAME": "isaura-public",
+    "DEFAULT_PRIVATE_BUCKET_NAME": "isaura-private",
+    "MINIO_LOCAL_AK": "minioadmin123",
+    "MINIO_LOCAL_SK": "minioadmin1234",
+}
+
+_SECRET_TOKENS = {"AK", "SK", "KEY", "PASSWORD", "SECRET"}
+
+
+def _is_secret(key: str) -> bool:
+    upper = key.upper()
+    return "CLOUD" in upper and any(tok in upper for tok in _SECRET_TOKENS)
+
+
+def _mask(value: str) -> str:
+    return "••••••••"
+
+
+def _read_env_file(path: Path) -> dict:
+    """Return key/value pairs from a .env file, ignoring comments and blanks."""
+    result = {}
+    if not path.exists():
+        return result
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            k, _, v = line.partition("=")
+            result[k.strip()] = v.strip().strip('"').strip("'")
+    return result
+
+
+def _write_env_file(path: Path, vars_dict: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{k}={v}" for k, v in vars_dict.items()]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def configure_show(reveal: bool = False) -> None:
+    """Display the current configuration as a table, masking secrets unless reveal=True."""
+    if not ENV_PATH.exists():
+        console.print(
+            "[yellow]No configuration file found.[/] "
+            "It will be created automatically the next time you run an isaura command."
+        )
+        return
+
+    existing = _read_env_file(ENV_PATH)
+    table = Table(title=f"isaura configuration  ({ENV_PATH})", show_lines=False)
+    table.add_column("Variable", style="bold")
+    table.add_column("Value")
+
+    for key, value in existing.items():
+        display = value if (reveal or not _is_secret(key)) else _mask(value)
+        table.add_row(key, display)
+
+    console.print(table)
+
+
+def configure_remote_interactive() -> None:
+    """Interactively prompt for remote/cloud credentials and merge into ~/.isaura/.env."""
+    console.print(Panel(
+        "You will be asked for your remote MinIO credentials.\n"
+        "Secret keys are hidden as you type.\n"
+        "Press [bold]Enter[/bold] to keep the current value where shown.",
+        title="Remote configuration",
+        border_style="blue",
+    ))
+
+    existing = _read_env_file(ENV_PATH)
+
+    endpoint = click.prompt(
+        "Cloud endpoint",
+        default=existing.get("MINIO_ENDPOINT_CLOUD", "http://83.48.73.209:8080"),
+    )
+    pub_ak = click.prompt("Public access key", hide_input=True)
+    pub_sk = click.prompt("Public secret key", hide_input=True)
+
+    console.print("[dim]Private bucket credentials are optional — press Enter to skip.[/]")
+    priv_ak = click.prompt("Private access key (optional)", default="", hide_input=True, show_default=False)
+    priv_sk = click.prompt("Private secret key (optional)", default="", hide_input=True, show_default=False)
+
+    updates = {
+        "MINIO_ENDPOINT_CLOUD": endpoint,
+        "MINIO_CLOUD_AK": pub_ak,
+        "MINIO_CLOUD_SK": pub_sk,
+    }
+    if priv_ak:
+        updates["MINIO_PRIV_CLOUD_AK"] = priv_ak
+    if priv_sk:
+        updates["MINIO_PRIV_CLOUD_SK"] = priv_sk
+
+    merged = {**existing, **updates}
+    _write_env_file(ENV_PATH, merged)
+    console.print(f"[green]Remote credentials saved to {ENV_PATH}[/]")
+
+
+def _try_credential_check(endpoint, access, secret) -> tuple[bool | None, str]:
+    """Attempt a MinioStore credential check, returning (ok, message).
+
+    Returns (None, message) if the server is unreachable (ping → sys.exit),
+    (True, message) on success, (False, message) on auth failure.
+    """
+    from isaura.base import MinioStore
+    try:
+        store = MinioStore(endpoint=endpoint, access=access, secret=secret)
+    except SystemExit:
+        return None, "[red]✗ server unreachable[/]"
+    except Exception:
+        return None, "[red]✗ server unreachable[/]"
+    ok = store.credential_check()
+    return ok, ("[green]✓ connected[/]" if ok else "[red]✗ auth failed[/]")
+
+
+def configure_test_credentials() -> None:
+    """Test local and cloud MinIO credentials and print a result table."""
+    from isaura.metadata import docker_is_running
+
+    rows = []
+
+    # Local
+    if not docker_is_running():
+        rows.append({"target": "Local", "bucket": DEFAULT_BUCKET_NAME, "result": "[red]✗ Docker not running[/]"})
+    else:
+        _, msg = _try_credential_check(MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK)
+        rows.append({"target": "Local", "bucket": DEFAULT_BUCKET_NAME, "result": msg})
+
+    # Cloud public
+    if not MINIO_CLOUD_AK:
+        rows.append({"target": "Cloud public", "bucket": DEFAULT_BUCKET_NAME,
+                     "result": "[yellow]✗ not configured[/]  run [bold]isaura configure --remote[/bold]"})
+    else:
+        _, msg = _try_credential_check(MINIO_ENDPOINT_CLOUD, MINIO_CLOUD_AK, MINIO_CLOUD_SK)
+        rows.append({"target": "Cloud public", "bucket": DEFAULT_BUCKET_NAME, "result": msg})
+
+    # Cloud private
+    if not MINIO_PRIV_CLOUD_AK:
+        rows.append({"target": "Cloud private", "bucket": DEFAULT_PRIVATE_BUCKET_NAME,
+                     "result": "[yellow]✗ not configured[/]  run [bold]isaura configure --remote[/bold]"})
+    else:
+        _, msg = _try_credential_check(MINIO_ENDPOINT_CLOUD, MINIO_PRIV_CLOUD_AK, MINIO_PRIV_CLOUD_SK)
+        rows.append({"target": "Cloud private", "bucket": DEFAULT_PRIVATE_BUCKET_NAME, "result": msg})
+
+    table = Table(title="Credential check", show_lines=False)
+    table.add_column("Target", style="bold")
+    table.add_column("Bucket")
+    table.add_column("Result")
+    for row in rows:
+        table.add_row(row["target"], row["bucket"], row["result"])
+    console.print(table)
+
+
+def configure_update_interactive() -> None:
+    """Arrow-key selector to update any single credential in ~/.isaura/.env."""
+    existing = _read_env_file(ENV_PATH)
+    if not existing:
+        console.print(
+            "[red]No configuration file found.[/] "
+            "Run any isaura command first to create it, then try again."
+        )
+        sys.exit(1)
+
+    choices = [
+        questionary.Choice(
+            title=f"{key}  (current: {_mask(val) if _is_secret(key) else val})",
+            value=key,
+        )
+        for key, val in existing.items()
+    ]
+
+    selected_key = questionary.select(
+        "Which credential do you want to update?",
+        choices=choices,
+    ).ask()
+
+    if selected_key is None:
+        console.print("[dim]No changes made.[/]")
+        return
+
+    if _is_secret(selected_key):
+        new_val = questionary.password(f"New value for {selected_key}:").ask()
+    else:
+        new_val = questionary.text(
+            f"New value for {selected_key}:",
+            default=existing[selected_key],
+        ).ask()
+
+    if new_val is None:
+        console.print("[dim]No changes made.[/]")
+        return
+
+    confirmed = questionary.confirm(
+        f"Are you sure you want to update {selected_key}?",
+        default=False,
+    ).ask()
+
+    if confirmed:
+        existing[selected_key] = new_val
+        _write_env_file(ENV_PATH, existing)
+        console.print(f"[green]{selected_key} updated successfully.[/]")
+    else:
+        console.print("[dim]No changes made.[/]")

--- a/isaura/const.py
+++ b/isaura/const.py
@@ -3,7 +3,18 @@ from pathlib import Path
 
 try:
   from dotenv import load_dotenv
-  load_dotenv(override=False)
+  _user_env = Path.home() / ".isaura" / ".env"
+  if not _user_env.exists():
+    _user_env.parent.mkdir(parents=True, exist_ok=True)
+    _user_env.write_text(
+      "MINIO_ENDPOINT=http://127.0.0.1:9000\n"
+      "NNS_ENDPOINT=http://127.0.0.1:8080\n"
+      "DEFAULT_BUCKET_NAME=isaura-public\n"
+      "DEFAULT_PRIVATE_BUCKET_NAME=isaura-private\n"
+      "MINIO_LOCAL_AK=minioadmin123\n"
+      "MINIO_LOCAL_SK=minioadmin1234\n"
+    )
+  load_dotenv(dotenv_path=_user_env, override=True)
 except Exception:
   pass
 

--- a/isaura/helpers.py
+++ b/isaura/helpers.py
@@ -12,7 +12,7 @@ from isaura.nns import (  # noqa: F401
   group_inputs, post_apprx, start_build_index,
 )
 from isaura.metadata import (  # noqa: F401
-  fetch_schema_from_github, output_dimension_from_metadata,
+  fetch_schema_from_github, get_engine_status, output_dimension_from_metadata,
   pick_meta, run_docker_compose, show_figlet,
   tranche_coordinates, write_access_file,
 )

--- a/isaura/logging.py
+++ b/isaura/logging.py
@@ -27,13 +27,18 @@ class Logger:
     self._file = None
     self._log_to_console()
 
-  def _log_to_console(self):
-    if self._console is None:
-      rich_handler = RichHandler(
-        rich_tracebacks=True, markup=True, log_time_format="%H:%M:%S", show_path=False
-      )
-      self._rich_console = rich_handler.console
-      self._console = self.logger.add(rich_handler, format="{message}", colorize=True)
+  def _log_to_console(self, level="INFO"):
+    if self._console is not None:
+      try:
+        self.logger.remove(self._console)
+      except Exception:
+        pass
+      self._console = None
+    rich_handler = RichHandler(
+      rich_tracebacks=True, markup=True, log_time_format="%H:%M:%S", show_path=False
+    )
+    self._rich_console = rich_handler.console
+    self._console = self.logger.add(rich_handler, format="{message}", colorize=True, level=level)
 
   @property
   def console(self):
@@ -48,11 +53,8 @@ class Logger:
       self._console = None
 
   def set_verbosity(self, verbose):
-    """Enable or disable console log output."""
-    if verbose:
-      self._log_to_console()
-    else:
-      self._unlog_from_console()
+    """Set console log level: DEBUG when verbose=True, INFO otherwise."""
+    self._log_to_console(level="DEBUG" if verbose else "INFO")
 
   def debug(self, text):
     self.logger.debug(text)

--- a/isaura/manage.py
+++ b/isaura/manage.py
@@ -407,6 +407,7 @@ class IsauraReader:
     self.tmpdir = make_temp("isaura_reader_")
     bind_temp_dirs(self, self.tmpdir)
     self.store = MinioStore(endpoint=self.endpoint, access=access_key, secret=secrete)
+    self.store.require_bucket(self.bucket)
     self.duck = DuckDBMinio(endpoint=self.endpoint, access=access_key, secret=secrete)
     self.bi = BloomIndex(
       self.store,
@@ -1413,10 +1414,9 @@ class IsauraInspect:
     return (union, owner)
 
   def list_available(self, output_csv=None):
-    """Return a DataFrame of all stored inputs with columns: input, model_version, access."""
+    """Return a DataFrame of all stored inputs with a single column: input."""
     _, owner = self._indices_union(force=self.cloud)
-    model_version = f"{self.model_id}_{self.model_version}" if self.model_id else (self.model_version or "")
-    df = pd.DataFrame([{"input": smi, "model_version": model_version, "bucket": b} for smi, b in owner.items()])
+    df = pd.DataFrame([{"input": smi} for smi in owner])
     if output_csv:
       df.to_csv(output_csv, index=False)
     return df
@@ -1424,13 +1424,12 @@ class IsauraInspect:
   def inspect_inputs(self, input_csv, output_csv=None):
     """Check which inputs from input_csv are available in the store.
 
-    Returns a DataFrame with columns: input, model_version, access.
+    Returns a DataFrame with a single column: input.
     """
     _, owner = self._indices_union(force=self.cloud)
     with open(input_csv, newline="", encoding="utf-8") as f:
       wanted = [(r.get("input") or "").strip() for r in csv.DictReader(f) if (r.get("input") or "").strip()]
-    model_version = f"{self.model_id}_{self.model_version}" if self.model_id else (self.model_version or "")
-    df = pd.DataFrame([{"input": s, "model_version": model_version, "bucket": owner[s]} for s in wanted if s in owner])
+    df = pd.DataFrame([{"input": s} for s in wanted if s in owner])
     if output_csv:
       df.to_csv(output_csv, index=False)
     return df

--- a/isaura/manage.py
+++ b/isaura/manage.py
@@ -7,6 +7,7 @@ from rich.progress import (
   SpinnerColumn,
   TextColumn,
   BarColumn,
+  TaskProgressColumn,
   TimeElapsedColumn,
   TimeRemainingColumn,
 )
@@ -271,7 +272,11 @@ class IsauraWriter:
         df.iloc[start : start + WRITE_INPUT_CHUNK_ROWS] for start in range(0, len(df), WRITE_INPUT_CHUNK_ROWS)
       )
     else:
-      total_rows = None
+      try:
+        with open(self.input_csv, "rb") as _f:
+          total_rows = sum(1 for _ in _f) - 1  # subtract header
+      except Exception:
+        total_rows = None
       chunk_iter = pd.read_csv(self.input_csv, chunksize=WRITE_INPUT_CHUNK_ROWS)
     progress = None
     task_id = None
@@ -281,8 +286,10 @@ class IsauraWriter:
           SpinnerColumn(),
           TextColumn("[progress.description]{task.description}"),
           BarColumn(),
+          TaskProgressColumn(text_format="[bold bright_cyan]{task.percentage:>3.0f}%[/]"),
           TextColumn("{task.completed}" + ("/{task.total}" if total_rows else "")),
           TimeElapsedColumn(),
+          TimeRemainingColumn(),
           console=logger.console,
           transient=False,
         )
@@ -670,7 +677,7 @@ class IsauraReader:
       total_rows = 0
       n_chunks = 0
       mode, payload = self._make_read_source(wanted, header, ordered=True)
-      with ReadProgress(total_inputs=len(wanted), console=logger.console) as progress:
+      with ReadProgress(total_inputs=len(wanted), console=logger.console, description=f"Reading [bold]{self.model_id}[/bold] → [bold]{self.bucket}[/bold]") as progress:
         if mode == "wide":
           source = stream_parquet_filtered(
             self.store,
@@ -750,7 +757,7 @@ class IsauraReader:
     source = None
     try:
       mode, payload = self._make_read_source(wanted, header, batch_size=batch_size, ordered=True)
-      with ReadProgress(total_inputs=len(wanted), console=logger.console) as progress:
+      with ReadProgress(total_inputs=len(wanted), console=logger.console, description=f"Reading [bold]{self.model_id}[/bold] → [bold]{self.bucket}[/bold]") as progress:
         if mode == "wide":
           raw_parts = []
           for chunk in stream_parquet_filtered(
@@ -1082,7 +1089,7 @@ class IsauraPull(_BaseTransfer):
     """Read outputs from cloud MinIO for the given inputs and store them locally."""
     t0 = time.time()
     input_name = os.path.basename(self.input_csv) if self.input_csv else ""
-    logger.debug(f"Pulling {self.model_id} ({self.model_version}) from {self.bucket}")
+    console.print(f"Pulling [bold]{self.model_id}[/bold] ({self.model_version}) from [bold]{self.bucket}[/bold]")
     with IsauraReader(
       model_id=self.model_id,
       model_version=self.model_version,
@@ -1093,15 +1100,16 @@ class IsauraPull(_BaseTransfer):
       access_key=mcak,
       secrete=mcsk,
     ) as r:
-      wanted, _ = r._wanted()
-      logger.debug(f"✓ {len(wanted)} inputs loaded from {input_name}")
-      r._prepare_read()
-      logger.debug(f"✓ All {len(wanted)} found in cloud index")
+      with console.status("Loading inputs...", spinner="dots"):
+        wanted, _ = r._wanted()
+      console.print(f"[green]✓[/green] {len(wanted):,} inputs loaded from {input_name}")
+      with console.status("Checking cloud index...", spinner="dots"):
+        r._prepare_read()
+      console.print(f"[green]✓[/green] All {len(wanted):,} found in cloud index")
       fetch_t0 = time.time()
       out = self._pull_batched(r.read_batched())
-      logger.debug(f"✓ {out[0]} rows fetched from cloud ({time.time() - fetch_t0:.1f}s)")
-      logger.debug(f"✓ {out[0]} rows stored locally")
-    console.print(f"[green]✓[/green] [bold]{self.model_id}/{self.model_version}[/bold] pulled [bold]{out[0]}[/bold] rows from [bold]{self.bucket}[/bold] in {time.time() - t0:.1f}s")
+      console.print(f"[green]✓[/green] {out[0]:,} rows fetched and stored locally ({time.time() - fetch_t0:.1f}s)")
+    console.print(f"[green]✓[/green] [bold]{self.model_id}/{self.model_version}[/bold] pulled [bold]{out[0]:,}[/bold] rows from [bold]{self.bucket}[/bold] in {time.time() - t0:.1f}s")
     logger.debug(f"pulled objects={out}")
 
 
@@ -1188,7 +1196,7 @@ class IsauraPush:
         if not obj["Key"].endswith(skip_suffixes)
       ]
       if not keys:
-        logger.warning(f"[push] no data for {self.model_id} in {src_bucket}. Skipping {access}.")
+        logger.debug(f"[push] no data for {self.model_id} in {src_bucket}. Skipping {access}.")
         continue
       has_data = True
       dst_bucket = f"isaura-{access}"

--- a/isaura/manage.py
+++ b/isaura/manage.py
@@ -34,6 +34,7 @@ from isaura.helpers import (
   release_temp_dirs,
   chunk_row_limit,
   logger,
+  console,
   output_dimension_from_metadata,
   rss_mb,
   fetch_schema_from_github,
@@ -152,7 +153,6 @@ class IsauraWriter:
     input_csv,
     model_id,
     model_version,
-    access="public",
     bucket=None,
     endpoint=None,
     access_key=None,
@@ -161,7 +161,6 @@ class IsauraWriter:
     self.input_csv = input_csv
     self.model_id = model_id
     self.model_version = model_version
-    self.access = access
     self.bucket = bucket or PUB
     self.base_prefix = get_base(self.model_id, model_version)
     self.access_key = get_acc_key(self.base_prefix)
@@ -169,8 +168,9 @@ class IsauraWriter:
     self.output_dimension = output_dimension_from_metadata(self.model_meta)
     self.max_rows = int(chunk_row_limit(self.output_dimension))
     self.store = MinioStore(endpoint=endpoint, access=access_key, secret=secrete)
-    self.store.ensure_bucket(self.bucket)
+    self.store.require_bucket(self.bucket)
     self.tmpdir = make_temp("isaura_writter_")
+    self.access = self._read_bucket_access()
     bind_temp_dirs(self, self.tmpdir)
     self.metadata_path = os.path.join(self.tmpdir, ACCESS_FILE)
     self.bi = BloomIndex(
@@ -191,9 +191,23 @@ class IsauraWriter:
     self.buffers = []
     self.buf_rows = 0
     self.schema_cols = None
-    logger.info(
+    logger.debug(
       f"writer init: bucket={self.bucket} base={self.base_prefix} csv={self.input_csv} output_dim={self.output_dimension} chunk_limit={self.max_rows}"
     )
+
+  def _read_bucket_access(self):
+    """Resolve access level: hardcoded for canonical buckets, read from access.json for custom ones."""
+    if self.bucket == PUB:
+      return "public"
+    if self.bucket == PRI:
+      return "private"
+    local = os.path.join(self.tmpdir, f"bucket_access_{uuid.uuid4().hex}.json")
+    try:
+      self.store.download_file(self.bucket, ACCESS_FILE, local)
+      with open(local, "r", encoding="utf-8") as f:
+        return json.load(f).get("access", "public")
+    except Exception:
+      return "public"
 
   def _load_metadata(self):
     """Download and parse the existing access metadata file, or return None if absent."""
@@ -218,7 +232,7 @@ class IsauraWriter:
       existed = self._load_metadata()
       write_access_file(existed, inputs, self.access, self.metadata_path)
       self.store.upload_file(self.metadata_path, self.bucket, f"{self.base_prefix}/{ACCESS_FILE}")
-      logger.info(f"{ACCESS_FILE} -> minio://{self.bucket}/{self.base_prefix}/{ACCESS_FILE}")
+      logger.debug(f"{ACCESS_FILE} -> minio://{self.bucket}/{self.base_prefix}/{ACCESS_FILE}")
     except Exception as e:
       logger.warning(f"metadata upload failed: {e}")
 
@@ -226,7 +240,7 @@ class IsauraWriter:
     """Infer and store column schema from the first row seen."""
     if self.schema_cols is None:
       self.schema_cols = list(row.keys())
-      logger.info(f"writer schema: {self.schema_cols[:10]}")
+      logger.debug(f"writer schema: {self.schema_cols[:10]}")
 
   def _flush_if_needed(self):
     """Flush the in-memory buffer to MinIO if it has reached max_rows."""
@@ -250,6 +264,7 @@ class IsauraWriter:
     """
     total = dupes = 0
     new = []
+    old_entries = len(self.bi.index) if self.bi.index is not None else 0
     if df is not None:
       total_rows = len(df)
       chunk_iter = (
@@ -262,34 +277,26 @@ class IsauraWriter:
     task_id = None
     try:
       if show_progress:
-        if total_rows is None:
-          progress = Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            TextColumn("{task.completed} rows"),
-            TimeElapsedColumn(),
-            console=logger.console,
-            transient=True,
-          )
-        else:
-          progress = Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("{task.completed}/{task.total}"),
-            TimeElapsedColumn(),
-            TimeRemainingColumn(),
-            console=logger.console,
-            transient=True,
-          )
+        progress = Progress(
+          SpinnerColumn(),
+          TextColumn("[progress.description]{task.description}"),
+          BarColumn(),
+          TextColumn("{task.completed}" + ("/{task.total}" if total_rows else "")),
+          TimeElapsedColumn(),
+          console=logger.console,
+          transient=False,
+        )
         progress.__enter__()
-        task_id = progress.add_task("Writing rows", total=total_rows)
+        task_id = progress.add_task(
+          f"Writing [bold]{self.model_id}[/bold] → [bold]{self.bucket}[/bold]",
+          total=total_rows,
+        )
       for chunk in chunk_iter:
         if chunk is None or chunk.empty:
           continue
         if self.schema_cols is None:
           self.schema_cols = list(chunk.columns)
-          logger.info(f"writer schema: {self.schema_cols[:10]}")
+          logger.debug(f"writer schema: {self.schema_cols[:10]}")
         if "input" in chunk.columns:
           inputs = chunk["input"].astype(str).str.strip()
         elif "smiles" in chunk.columns:
@@ -329,7 +336,10 @@ class IsauraWriter:
     entries = len(self.bi.index) if self.bi.index is not None else 0
     chunks = len(self.chunk_state._list_chunks())
     upload_catalog_json(self.store, self.bucket, self.base_prefix, entries, chunks, self.tmpdir)
-    logger.info(f"write done: new={total} dupes={dupes}")
+    actual_new = entries - old_entries
+    actual_dupes = (total + dupes) - actual_new
+    dupes_str = f", [dim]{actual_dupes} duplicates skipped[/dim]" if actual_dupes else ""
+    console.print(f"[green]✓[/green] [bold]{self.model_id}/{self.model_version}[/bold] → [bold]{self.bucket}[/bold]: [bold]{actual_new}[/bold] molecules written{dupes_str}")
 
   def close(self):
     """Release temporary directories created during construction."""
@@ -471,7 +481,7 @@ class IsauraReader:
     t0 = time.time()
     wanted, header = self._wanted(df=df)
     if self.approximate:
-      logger.info(f"[read:prepare] approximate mode — loading index for collection={self.collection}")
+      logger.debug(f"[read:prepare] approximate mode — loading index for collection={self.collection}")
       index = self._load_index()
       if index and len(index) < MIN_NNS_RESULT_SIZE:
         logger.error(
@@ -481,7 +491,7 @@ class IsauraReader:
       st = time.perf_counter()
       wanted = get_apprx(wanted, self.collection)
       et = time.perf_counter()
-      logger.info(f"Approximate inputs are retrieved {len(wanted)} in {et - st:.2f} seconds!")
+      logger.debug(f"Approximate inputs are retrieved {len(wanted)} in {et - st:.2f} seconds!")
       group_inputs(wanted, index, bloom=self.bi)
     else:
       logger.debug(f"[read:prepare] exact mode — checking bloom filter for {len(wanted)} inputs")
@@ -654,7 +664,7 @@ class IsauraReader:
     """
     t0, wanted, header = self._prepare_read(df=df)
     if not wanted:
-      logger.info("[read] no inputs — returning empty frame")
+      logger.debug("[read] no inputs — returning empty frame")
       return pd.DataFrame()
     try:
       total_rows = 0
@@ -696,7 +706,7 @@ class IsauraReader:
           result = self._reorder(wanted, header, result)
           total_rows = len(result)
       if output_csv and not result.empty:
-        logger.info(f"[read] writing csv to {output_csv}")
+        logger.debug(f"[read] writing csv to {output_csv}")
         with StreamingCsvSink(output_csv) as sink:
           sink.write_df(result)
         out = pd.DataFrame()
@@ -705,7 +715,7 @@ class IsauraReader:
       else:
         out = result
       elapsed = time.time() - t0
-      logger.success(f"Query successfully fetched for a given inputs in {elapsed:.2f} sec")
+      logger.debug(f"Query successfully fetched for a given inputs in {elapsed:.2f} sec")
     except Exception as e:
       logger.error(f"[read] query failed: {e}")
       sys.exit(1)
@@ -813,7 +823,7 @@ class IsauraCopy(_BaseTransfer):
 
   def copy(self):
     """Run the copy operation. Loads access metadata and routes rows to the right buckets."""
-    logger.info(f"[copy] starting model={self.model_id} v={self.model_version} bucket={self.bucket}")
+    logger.debug(f"[copy] starting model={self.model_id} v={self.model_version} bucket={self.bucket}")
     meta_local, meta = self._load_metadata()
     return self._copy(meta_local, meta)
 
@@ -856,6 +866,204 @@ class IsauraRemover(_BaseTransfer):
       logger.info(f"removed objects={n}")
 
 
+class IsauraMolRemover:
+  """Removes specific molecules from a model's stored data in a bucket.
+
+  Downloads each Parquet chunk, filters out the requested rows, and re-uploads
+  the modified chunks. Rebuilds the Bloom filter and JSON index from scratch,
+  and updates the per-model access.json and catalog.json.
+
+  Args:
+      model_id: Ersilia model identifier.
+      model_version: Model version string.
+      bucket: Target MinIO bucket.
+      input_csv: Path to a CSV file with an "input" or "smiles" column.
+  """
+
+  def __init__(self, model_id, model_version, bucket, input_csv):
+    self.model_id = model_id
+    self.model_version = model_version
+    self.bucket = bucket
+    self.input_csv = input_csv
+    self.base_prefix = get_base(model_id, model_version)
+    self.store = MinioStore()
+    self.store.require_bucket(bucket)
+    self.tmpdir = make_temp("isaura_mol_remover_")
+    bind_temp_dirs(self, self.tmpdir)
+
+  def _read_inputs(self):
+    """Parse the input CSV and return a list of molecule strings."""
+    inputs = []
+    with open(self.input_csv, newline="", encoding="utf-8") as f:
+      for row in csv.DictReader(f):
+        v = (row.get("input") or row.get("smiles") or "").strip()
+        if v:
+          inputs.append(v)
+    return inputs
+
+  def _list_chunk_keys(self):
+    """Return a sorted list of Parquet chunk keys for this model."""
+    pref = hive_prefix(self.base_prefix) + "/"
+    keys = [
+      obj["Key"] for obj in self.store.list_keys(self.bucket, pref)
+      if obj["Key"].endswith(".parquet") and "/chunk_" in obj["Key"]
+    ]
+    def _idx(key):
+      try:
+        return int(os.path.basename(key).split("_")[1].split(".")[0])
+      except Exception:
+        return 0
+    return sorted(keys, key=_idx)
+
+  def _rewrite_chunk(self, chunk_key, to_remove):
+    """Download a chunk, filter out to_remove rows, re-upload (or delete if empty).
+
+    Returns:
+        Tuple of (rows_before, rows_after).
+    """
+    import pyarrow as pa
+    local = os.path.join(self.tmpdir, f"chunk_dl_{uuid.uuid4().hex}.parquet")
+    local_out = os.path.join(self.tmpdir, f"chunk_out_{uuid.uuid4().hex}.parquet")
+    try:
+      self.store.download_file(self.bucket, chunk_key, local)
+      pf = pq.ParquetFile(local)
+      schema_names = pf.schema_arrow.names
+      input_col = next((c for c in ["input", "smiles"] if c in schema_names), schema_names[0])
+      rows_before = pf.metadata.num_rows
+      df = pf.read().to_pandas()
+      mask = ~df[input_col].astype(str).str.strip().isin(to_remove)
+      filtered = df.loc[mask].reset_index(drop=True)
+      rows_after = len(filtered)
+      if rows_after == 0:
+        self.store.client.delete_object(Bucket=self.bucket, Key=chunk_key)
+        logger.debug(f"[remove] deleted empty chunk {chunk_key}")
+      else:
+        table = pa.Table.from_pandas(filtered, preserve_index=False)
+        pq.write_table(table, local_out)
+        self.store.upload_file(local_out, self.bucket, chunk_key)
+        logger.debug(f"[remove] rewrote chunk {chunk_key}: {rows_before}→{rows_after} rows")
+      return (rows_before, rows_after)
+    except Exception as e:
+      logger.error(f"[remove] chunk {chunk_key}: {e}")
+      return (0, 0)
+    finally:
+      for f in [local, local_out]:
+        try:
+          os.remove(f)
+        except Exception:
+          pass
+
+  def _update_access_json(self, to_remove):
+    """Remove deleted molecules from the per-model access.json and re-upload."""
+    acc_key = get_acc_key(self.base_prefix)
+    local = os.path.join(self.tmpdir, f"access_upd_{uuid.uuid4().hex}.json")
+    try:
+      self.store.download_file(self.bucket, acc_key, local)
+      with open(local, "r", encoding="utf-8") as f:
+        data = json.load(f)
+      if isinstance(data, list):
+        filtered = [d for d in data if (d.get("input") or "").strip() not in to_remove]
+        with open(local, "w", encoding="utf-8") as f:
+          json.dump(filtered, f, indent=2)
+        self.store.upload_file(local, self.bucket, acc_key)
+        logger.debug(f"[remove] access.json: {len(data)}→{len(filtered)}")
+    except Exception as e:
+      logger.debug(f"[remove] access.json update skipped: {e}")
+    finally:
+      try:
+        os.remove(local)
+      except Exception:
+        pass
+
+  def remove(self, show_progress=True):
+    """Remove the specified molecules from the store.
+
+    Returns:
+        Tuple of (n_removed, n_not_found).
+    """
+    to_remove_list = self._read_inputs()
+    if not to_remove_list:
+      logger.error("No valid molecules found in input file.")
+      sys.exit(1)
+    to_remove = set(to_remove_list)
+
+    bi = BloomIndex(self.store, self.bucket, self.base_prefix, self.tmpdir)
+    if not bi.index:
+      logger.error(f"No index found for {self.model_id}/{self.model_version} in {self.bucket}.")
+      sys.exit(1)
+
+    actually_present = to_remove & set(bi.index.keys())
+    n_not_found = len(to_remove) - len(actually_present)
+
+    if not actually_present:
+      return (0, len(to_remove))
+
+    chunk_keys = self._list_chunk_keys()
+    if not chunk_keys:
+      logger.error("No chunk files found.")
+      sys.exit(1)
+
+    total_removed = 0
+    progress = None
+    task_id = None
+    try:
+      if show_progress:
+        progress = Progress(
+          SpinnerColumn(),
+          TextColumn("[progress.description]{task.description}"),
+          BarColumn(),
+          TextColumn("{task.completed}/{task.total}"),
+          TimeElapsedColumn(),
+          console=logger.console,
+          transient=False,
+        )
+        progress.__enter__()
+        task_id = progress.add_task(
+          f"Removing from [bold]{self.model_id}[/bold] → [bold]{self.bucket}[/bold]",
+          total=len(chunk_keys),
+        )
+      for key in chunk_keys:
+        rows_before, rows_after = self._rewrite_chunk(key, actually_present)
+        total_removed += rows_before - rows_after
+        if progress is not None and task_id is not None:
+          progress.advance(task_id, 1)
+    finally:
+      if progress is not None:
+        progress.__exit__(None, None, None)
+
+    for k in actually_present:
+      bi.index.pop(k, None)
+    from pybloom_live import ScalableBloomFilter
+    bi.sbf = ScalableBloomFilter(
+      mode=ScalableBloomFilter.SMALL_SET_GROWTH,
+      initial_capacity=max(1000000, len(bi.index)),
+      error_rate=1e-14,
+    )
+    for k in bi.index:
+      bi.sbf.add(k)
+    bi._added = 1
+    bi.persist()
+
+    self._update_access_json(actually_present)
+
+    remaining_chunks = self._list_chunk_keys()
+    upload_catalog_json(
+      self.store, self.bucket, self.base_prefix, len(bi.index), len(remaining_chunks), self.tmpdir
+    )
+
+    return (total_removed, n_not_found)
+
+  def close(self):
+    """Release temporary directories."""
+    release_temp_dirs(self)
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, et, ev, tb):
+    self.close()
+
+
 class IsauraPull(_BaseTransfer):
   """Downloads precalculated outputs from the cloud MinIO and stores them locally.
 
@@ -874,7 +1082,7 @@ class IsauraPull(_BaseTransfer):
     """Read outputs from cloud MinIO for the given inputs and store them locally."""
     t0 = time.time()
     input_name = os.path.basename(self.input_csv) if self.input_csv else ""
-    logger.info(f"Pulling {self.model_id} ({self.model_version}) from {self.bucket}")
+    logger.debug(f"Pulling {self.model_id} ({self.model_version}) from {self.bucket}")
     with IsauraReader(
       model_id=self.model_id,
       model_version=self.model_version,
@@ -886,14 +1094,14 @@ class IsauraPull(_BaseTransfer):
       secrete=mcsk,
     ) as r:
       wanted, _ = r._wanted()
-      logger.info(f"✓ {len(wanted)} inputs loaded from {input_name}")
+      logger.debug(f"✓ {len(wanted)} inputs loaded from {input_name}")
       r._prepare_read()
-      logger.info(f"✓ All {len(wanted)} found in cloud index")
+      logger.debug(f"✓ All {len(wanted)} found in cloud index")
       fetch_t0 = time.time()
       out = self._pull_batched(r.read_batched())
-      logger.info(f"✓ {out[0]} rows fetched from cloud ({time.time() - fetch_t0:.1f}s)")
-      logger.info(f"✓ {out[0]} rows stored locally")
-    logger.info(f"Done — pulled {out[0]} rows in {time.time() - t0:.1f}s")
+      logger.debug(f"✓ {out[0]} rows fetched from cloud ({time.time() - fetch_t0:.1f}s)")
+      logger.debug(f"✓ {out[0]} rows stored locally")
+    console.print(f"[green]✓[/green] [bold]{self.model_id}/{self.model_version}[/bold] pulled [bold]{out[0]}[/bold] rows from [bold]{self.bucket}[/bold] in {time.time() - t0:.1f}s")
     logger.debug(f"pulled objects={out}")
 
 
@@ -959,7 +1167,7 @@ class IsauraPush:
       1 for obj in cloud_store.list_keys(dst_bucket, pref)
       if obj["Key"].endswith(".parquet") and "/chunk_" in obj["Key"]
     )
-    logger.info(f"[push] merged bloom+index: entries={merged_entries} chunks={cloud_chunks}")
+    logger.debug(f"[push] merged bloom+index: entries={merged_entries} chunks={cloud_chunks}")
     return (merged_entries, cloud_chunks)
 
   def push(self):
@@ -987,7 +1195,7 @@ class IsauraPush:
       cloud_store = MinioStore(endpoint=MINIO_ENDPOINT_CLOUD, access=mck, secret=mcs)
       cloud_store.ensure_bucket(dst_bucket)
       tmpdir = make_temp("isaura_push_")
-      logger.info(
+      logger.debug(
         f"[push] uploading {len(keys)} objects for {self.model_id}/{self.model_version} "
         f"({access}) to cloud"
       )
@@ -1009,7 +1217,7 @@ class IsauraPush:
                 errors.append(err)
         for err in errors:
           logger.warning(err)
-        logger.info(f"[push] {access} done: {done}/{len(keys)} objects uploaded to cloud")
+        logger.debug(f"[push] {access} done: {done}/{len(keys)} objects uploaded to cloud")
         with logger.console.status("Merging bloom filter and index...", spinner="dots"):
           merged_entries, cloud_chunks = self._merge_bloom_index(
             local_store, src_bucket, cloud_store, dst_bucket, tmpdir
@@ -1024,6 +1232,7 @@ class IsauraPush:
     if not has_data:
       logger.error("No data found in any default bucket for a given model! Aborting push.")
       sys.exit(1)
+    console.print(f"[green]✓[/green] [bold]{self.model_id}/{self.model_version}[/bold] pushed to cloud")
 
 
 class IsauraInspect:
@@ -1196,9 +1405,10 @@ class IsauraInspect:
     return (union, owner)
 
   def list_available(self, output_csv=None):
-    """Return a DataFrame of all stored inputs and their source bucket."""
+    """Return a DataFrame of all stored inputs with columns: input, model_version, access."""
     _, owner = self._indices_union(force=self.cloud)
-    df = pd.DataFrame([{"input": smi, "bucket": b} for smi, b in owner.items()])
+    model_version = f"{self.model_id}_{self.model_version}" if self.model_id else (self.model_version or "")
+    df = pd.DataFrame([{"input": smi, "model_version": model_version, "bucket": b} for smi, b in owner.items()])
     if output_csv:
       df.to_csv(output_csv, index=False)
     return df
@@ -1206,12 +1416,13 @@ class IsauraInspect:
   def inspect_inputs(self, input_csv, output_csv=None):
     """Check which inputs from input_csv are available in the store.
 
-    Returns a DataFrame with columns: input, available (bool), bucket.
+    Returns a DataFrame with columns: input, model_version, access.
     """
     _, owner = self._indices_union(force=self.cloud)
     with open(input_csv, newline="", encoding="utf-8") as f:
       wanted = [(r.get("input") or "").strip() for r in csv.DictReader(f) if (r.get("input") or "").strip()]
-    df = pd.DataFrame([{"input": s, "available": s in owner, "bucket": owner.get(s, "")} for s in wanted])
+    model_version = f"{self.model_id}_{self.model_version}" if self.model_id else (self.model_version or "")
+    df = pd.DataFrame([{"input": s, "model_version": model_version, "bucket": owner[s]} for s in wanted if s in owner])
     if output_csv:
       df.to_csv(output_csv, index=False)
     return df

--- a/isaura/manage.py
+++ b/isaura/manage.py
@@ -406,7 +406,7 @@ class IsauraReader:
       self.model_meta = {}
     self.output_dimension = output_dimension_from_metadata(self.model_meta)
     self.wide_model = self.output_dimension is not None and self.output_dimension >= 100
-    logger.info(
+    logger.debug(
       f"reader init bucket={self.bucket} base={self.base} csv={self.input_csv} output_dim={self.output_dimension} wide={self.wide_model}"
     )
 
@@ -425,6 +425,8 @@ class IsauraReader:
     Returns:
         Tuple of (list_of_input_strings, column_header_name).
     """
+    if df is None and hasattr(self, "_cached_wanted"):
+      return self._cached_wanted
     wanted, header_set = ([], set())
     rows = df.to_dict("records") if df is not None else None
     if rows is None:
@@ -448,7 +450,9 @@ class IsauraReader:
         if h:
           header_set.add(h)
     header = list(header_set)[0] if header_set else "smiles"
-    logger.info(f"[read:wanted] collected inputs={len(wanted)} header={header}")
+    logger.debug(f"[read:wanted] collected inputs={len(wanted)} header={header}")
+    if df is None:
+      self._cached_wanted = (wanted, header)
     return (wanted, header)
 
   def _prepare_read(self, df=None):
@@ -461,6 +465,8 @@ class IsauraReader:
     Returns:
         Tuple of (start_time, resolved_wanted_list, header_column_name).
     """
+    if hasattr(self, "_cached_prepare"):
+      return self._cached_prepare
     index = None
     t0 = time.time()
     wanted, header = self._wanted(df=df)
@@ -478,19 +484,48 @@ class IsauraReader:
       logger.info(f"Approximate inputs are retrieved {len(wanted)} in {et - st:.2f} seconds!")
       group_inputs(wanted, index, bloom=self.bi)
     else:
-      logger.info(f"[read:prepare] exact mode — checking bloom filter for {len(wanted)} inputs")
+      logger.debug(f"[read:prepare] exact mode — checking bloom filter for {len(wanted)} inputs")
       bloom_t0 = time.perf_counter()
       missing = [v for v in wanted if not self.bi.seen(v)]
       bloom_dt = time.perf_counter() - bloom_t0
-      logger.info(f"[read:prepare] bloom check done in {bloom_dt:.3f}s missing={len(missing)}")
+      logger.debug(f"[read:prepare] bloom check done in {bloom_dt:.3f}s missing={len(missing)}")
       if missing:
         logger.error(
           f"inputs not indexed: {missing[:5]}{('...' if len(missing) > 5 else '')} total_missing={len(missing)}"
         )
         sys.exit(1)
     prep_dt = time.time() - t0
-    logger.info(f"[read:prepare] ready inputs={len(wanted)} header={header} prep_time={prep_dt:.2f}s")
-    return (t0, wanted, header)
+    logger.debug(f"[read:prepare] ready inputs={len(wanted)} header={header} prep_time={prep_dt:.2f}s")
+    self._cached_prepare = (t0, wanted, header)
+    return self._cached_prepare
+
+  def _detect_parquet_col(self, header):
+    """Return the molecule column name actually used in stored Parquet files.
+
+    Downloads the first chunk file and inspects its schema. Falls back to
+    header if no known INPUT_C column is found.
+    """
+    prefix = hive_prefix(self.base) + "/"
+    try:
+      keys = [
+        obj["Key"]
+        for obj in self.store.list_keys(self.bucket, prefix)
+        if obj["Key"].endswith(".parquet") and "/chunk_" in obj["Key"]
+      ]
+      if not keys:
+        return header
+      local = os.path.join(self.tmpdir, f"schema_probe_{uuid.uuid4().hex}.parquet")
+      try:
+        self.store.download_file(self.bucket, keys[0], local)
+        schema_names = set(pq.ParquetFile(local).schema_arrow.names)
+        return next((c for c in [header] + INPUT_C if c in schema_names), header)
+      finally:
+        try:
+          os.remove(local)
+        except Exception:
+          pass
+    except Exception:
+      return header
 
   def _make_read_source(self, wanted, header, batch_size=10000, ordered=True):
     """Choose a read strategy and return (mode, payload).
@@ -506,17 +541,28 @@ class IsauraReader:
     n = len(wanted)
     if self.wide_model:
       prefix = hive_prefix(self.base) + "/"
-      logger.info(f"[read] wide streaming n={n} bucket={self.bucket}")
+      logger.debug(f"[read] wide streaming n={n} bucket={self.bucket}")
       return "wide", prefix
     if n >= STREAM_PARQUET_THRESHOLD:
       prefix = hive_prefix(self.base) + "/"
-      logger.info(f"[read] streaming n={n} bucket={self.bucket}")
+      logger.debug(f"[read] streaming n={n} bucket={self.bucket}")
       return "stream", prefix
     files = list_parquet_keys(self.store, self.bucket, self.base)
-    logger.info(f"[read] duckdb n={n} bucket={self.bucket}")
-    return "duckdb", query_batched(
-      self.duck.con, header, wanted, files, batch_size=batch_size, tmpdir=self.tmpdir, preserve_order=ordered
+    parquet_col = self._detect_parquet_col(header)
+    logger.debug(f"[read] duckdb n={n} bucket={self.bucket}")
+    raw = query_batched(
+      self.duck.con, parquet_col, wanted, files, batch_size=batch_size, tmpdir=self.tmpdir, preserve_order=ordered
     )
+    if parquet_col == header:
+      return "duckdb", raw
+
+    def _rename(batches, src, dst):
+      for chunk in batches:
+        if src in chunk.columns:
+          chunk = chunk.rename(columns={src: dst})
+        yield chunk
+
+    return "duckdb", _rename(raw, parquet_col, header)
 
   def _load_index(self):
     """Download and parse the JSON index for this model. Returns [] on failure."""
@@ -664,7 +710,7 @@ class IsauraReader:
       logger.error(f"[read] query failed: {e}")
       sys.exit(1)
     rate = total_rows / elapsed if elapsed > 0 and total_rows else 0.0
-    logger.info(
+    logger.debug(
       f"[read] done model={self.pref} inputs={len(wanted)} matched={total_rows} "
       f"chunks={n_chunks} elapsed={time.time() - t0:.2f}s rate={rate:.1f}/s rss={rss_mb():.0f}MB"
     )
@@ -727,7 +773,7 @@ class IsauraReader:
         else:
           source = payload
         if output_csv:
-          logger.info(f"[read_batched] streaming csv to {output_csv}")
+          logger.debug(f"[read_batched] streaming csv to {output_csv}")
           sink = StreamingCsvSink(output_csv)
           sink.__enter__()
         for chunk in source:
@@ -745,13 +791,13 @@ class IsauraReader:
     finally:
       if sink is not None:
         sink.__exit__(None, None, None)
-        logger.info(f"[read_batched] csv closed rows={total_rows} path={output_csv}")
+        logger.debug(f"[read_batched] csv closed rows={total_rows} path={output_csv}")
       close = getattr(source, "close", None)
       if close is not None:
         close()
     elapsed = time.time() - t0
     rate = total_rows / elapsed if elapsed > 0 and total_rows else 0.0
-    logger.success(
+    logger.debug(
       f"[read_batched] done model={self.pref} inputs={len(wanted)} matched={total_rows} "
       f"chunks={n_chunks} elapsed={elapsed:.2f}s rate={rate:.1f}/s rss={rss_mb():.0f}MB"
     )
@@ -826,9 +872,9 @@ class IsauraPull(_BaseTransfer):
 
   def pull(self):
     """Read outputs from cloud MinIO for the given inputs and store them locally."""
-    logger.info(
-      f"Pulling precalculation from the cloud for model={self.model_id}, version={self.model_version}, bucket={self.bucket}"
-    )
+    t0 = time.time()
+    input_name = os.path.basename(self.input_csv) if self.input_csv else ""
+    logger.info(f"Pulling {self.model_id} ({self.model_version}) from {self.bucket}")
     with IsauraReader(
       model_id=self.model_id,
       model_version=self.model_version,
@@ -839,8 +885,16 @@ class IsauraPull(_BaseTransfer):
       access_key=mcak,
       secrete=mcsk,
     ) as r:
+      wanted, _ = r._wanted()
+      logger.info(f"✓ {len(wanted)} inputs loaded from {input_name}")
+      r._prepare_read()
+      logger.info(f"✓ All {len(wanted)} found in cloud index")
+      fetch_t0 = time.time()
       out = self._pull_batched(r.read_batched())
-    logger.info(f"pulled objects={out}")
+      logger.info(f"✓ {out[0]} rows fetched from cloud ({time.time() - fetch_t0:.1f}s)")
+      logger.info(f"✓ {out[0]} rows stored locally")
+    logger.info(f"Done — pulled {out[0]} rows in {time.time() - t0:.1f}s")
+    logger.debug(f"pulled objects={out}")
 
 
 class IsauraPush:

--- a/isaura/metadata.py
+++ b/isaura/metadata.py
@@ -10,7 +10,9 @@ from rdkit import Chem
 from rdkit.Chem import Descriptors, Crippen
 
 from isaura.const import (
+  DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME,
   GITHUB_CONTENT_URL, LOGP_BINS, METADATA_JSON, METADATA_YML,
+  MINIO_ENDPOINT, MINIO_LOCAL_AK, MINIO_LOCAL_SK,
   MKEYS, MW_BINS, _INT_KEYS, _KEYMAP,
 )
 from isaura.logging import logger
@@ -133,8 +135,82 @@ def tranche_coordinates(smiles):
   return (row, col, mw, logp)
 
 
-def run_docker_compose(up=True):
-  """Start or stop the MinIO/Milvus/NNS services via Docker Compose.
+def docker_is_installed() -> bool:
+  """Return True if the docker CLI is available on PATH."""
+  try:
+    subprocess.run(["docker", "--version"], capture_output=True, check=True, timeout=5)
+    return True
+  except (FileNotFoundError, subprocess.CalledProcessError):
+    return False
+
+
+def docker_is_running() -> bool:
+  """Return True if the Docker daemon is active and reachable."""
+  try:
+    result = subprocess.run(["docker", "info"], capture_output=True, timeout=5)
+    return result.returncode == 0
+  except Exception:
+    return False
+
+
+def get_engine_status() -> dict:
+  """Return the status of Docker and the isaura containers.
+
+  Returns:
+      Dict with keys "docker" (bool) and "containers" (list of {name, status}).
+  """
+  running = docker_is_installed() and docker_is_running()
+  containers = []
+  if running:
+    for name in ["minio"]:
+      try:
+        result = subprocess.run(
+          ["docker", "ps", "-a", "--filter", f"name=^{name}$", "--format", "{{.Status}}"],
+          capture_output=True, text=True, timeout=5,
+        )
+        status = result.stdout.strip() or "not created"
+      except Exception:
+        status = "unknown"
+      containers.append({"name": name, "status": status})
+  return {"docker": running, "containers": containers}
+
+
+def ensure_default_buckets(timeout: int = 30) -> None:
+  """Wait for local MinIO to be ready, then create the default buckets if they don't exist."""
+  import time
+  import boto3
+  from botocore.config import Config
+
+  url = f"{MINIO_ENDPOINT.rstrip('/')}/minio/health/ready"
+  for _ in range(timeout):
+    try:
+      if requests.get(url, timeout=2).status_code == 200:
+        break
+    except Exception:
+      pass
+    time.sleep(1)
+  else:
+    logger.warning("MinIO did not become ready in time — skipping default bucket creation.")
+    return
+
+  client = boto3.client(
+    "s3",
+    endpoint_url=MINIO_ENDPOINT,
+    aws_access_key_id=MINIO_LOCAL_AK,
+    aws_secret_access_key=MINIO_LOCAL_SK,
+    region_name="us-east-1",
+    config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
+  )
+  for bucket in [DEFAULT_BUCKET_NAME, DEFAULT_PRIVATE_BUCKET_NAME]:
+    try:
+      client.head_bucket(Bucket=bucket)
+    except Exception:
+      client.create_bucket(Bucket=bucket)
+      logger.info(f"Created default bucket: {bucket}")
+
+
+def run_docker_compose(up=True) -> bool:
+  """Start or stop the MinIO service via Docker Compose.
 
   Args:
       up: If True, runs `docker compose up -d`. If False, runs `docker compose down`.
@@ -142,18 +218,38 @@ def run_docker_compose(up=True):
   Returns:
       True on success, False on failure.
   """
-  try:
-    path = Path(__file__).parent / "configs" / "docker-compose.yml"
-    cmd = ["docker", "compose", "-f", path, "up", "-d"] if up else ["docker", "compose", "-f", path, "down"]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    logger.info(f"Docker Compose {'started' if up else 'stopped'} successfully.")
+  if not docker_is_installed():
+    logger.error("Docker is not installed. Please install Docker Desktop: https://docs.docker.com/get-docker/")
+    return False
+  if not docker_is_running():
+    logger.error("Docker is not running. Please open Docker Desktop and try again.")
+    return False
+
+  path = Path(__file__).parent / "configs" / "docker-compose.yml"
+
+  if up:
+    try:
+      check = subprocess.run(
+        ["docker", "image", "inspect", "minio/minio:latest"],
+        capture_output=True, timeout=5,
+      )
+      if check.returncode != 0:
+        logger.info("MinIO image not found locally — it will be downloaded now. This may take a few minutes on first run.")
+    except Exception:
+      pass
+    logger.info("Spinning up Docker containers...")
+    cmd = ["docker", "compose", "-f", str(path), "up", "-d"]
+  else:
+    logger.info("Stopping Docker containers...")
+    cmd = ["docker", "compose", "-f", str(path), "down"]
+
+  result = subprocess.run(cmd)
+  if result.returncode == 0:
+    logger.info(f"Containers {'started' if up else 'stopped'} successfully.")
+    if up:
+      ensure_default_buckets()
     return True
-  except subprocess.CalledProcessError as e:
-    logger.error(f"Docker Compose failed: {e.stderr.strip()}")
-  except FileNotFoundError:
-    logger.error("Docker is not installed or not in PATH.")
-  except Exception as e:
-    logger.error(f"Unexpected error: {e}")
+  logger.error(f"Docker Compose {'up' if up else 'down'} failed (exit code {result.returncode}).")
   return False
 
 
@@ -176,5 +272,10 @@ def show_figlet():
     gradient.append(ch, style=f"rgb({r},{g},{b})")
   print()
   console.print(gradient, justify="center")
-  console.print(Text("[New] Version 2.1.16", style="bold bright_black"), justify="center")
+  try:
+    from importlib.metadata import version
+    _version = version("isaura")
+  except Exception:
+    _version = "unknown"
+  console.print(Text(f"Version {_version}", style="bold bright_black"), justify="center")
   print()

--- a/isaura/nns.py
+++ b/isaura/nns.py
@@ -127,7 +127,7 @@ def post_apprx(df, collection, nlist=None):
   t0 = time.time()
   try:
     with requests.Session() as s:
-      log("start streaming to nns api")
+      logger.debug("start streaming to nns api")
       resp = s.post(
         f"{NNS_ENDPOINT_BASE}/insert",
         params=_get_params(collection),
@@ -136,19 +136,19 @@ def post_apprx(df, collection, nlist=None):
         timeout=None,
       )
     dt = (time.time() - t0) * 1000
-    log(f"done total_ms={dt:.0f}. Body: {resp.text[:1000]}")
+    logger.debug(f"done total_ms={dt:.0f}. Body: {resp.text[:1000]}")
     try:
       start_build_index(collection, nlist=nlist, rebuild=False, wait=False)
       st = build_index_status(collection)
-      logger.info(
+      logger.debug(
         f"index build triggered collection={collection} exists={st.get('exists')} "
         f"building={st.get('is_building')} finished={st.get('is_finished')}"
       )
     except requests.RequestException as e:
-      logger.error(f"index build trigger failed collection={collection}: {e}")
+      logger.debug(f"index build trigger failed collection={collection}: {e}")
     return resp
   except requests.RequestException as e:
-    logger.error(f"approx NN search failed: {e}")
+    logger.debug(f"approx NN search failed: {e}")
     return None
 
 
@@ -188,7 +188,7 @@ def get_apprx(inputs, collection, fallback_search=None):
     results = payload.get("results", [])
     return [x.get("match") for x in results if "match" in x]
   except requests.RequestException as e:
-    logger.error(f"approx NN search failed: {e}")
+    logger.debug(f"approx NN search failed: {e}")
     if callable(fallback_search):
       return fallback_search(inputs, collection)
     return []

--- a/isaura/parquet.py
+++ b/isaura/parquet.py
@@ -83,7 +83,7 @@ def list_parquet_keys(store, bucket, base):
     keys.sort()
     uris = [f"s3://{bucket}/{k}" for k in keys]
     dt = time.perf_counter() - t0
-    logger.info(f"[list_parquet_keys] listed {len(uris)} files in {dt:.3f}s bucket={bucket} prefix={prefix}")
+    logger.debug(f"[list_parquet_keys] listed {len(uris)} files in {dt:.3f}s bucket={bucket} prefix={prefix}")
     return uris if uris else get_files_glob(bucket, base)
   except Exception as e:
     logger.warning(f"[list_parquet_keys] boto3 listing failed ({e}), falling back to glob")

--- a/isaura/progress.py
+++ b/isaura/progress.py
@@ -130,7 +130,7 @@ class ReadProgress:
       TextColumn("[yellow]pending[/] {task.fields[unresolved]}"),
       TextColumn("[magenta]rss[/] {task.fields[rss]}MB"),
       TimeElapsedColumn(), TimeRemainingColumn(),
-      console=self.console, transient=True,
+      console=self.console, transient=False,
       redirect_stdout=False, redirect_stderr=False,
       refresh_per_second=10, expand=True,
     )

--- a/isaura/progress.py
+++ b/isaura/progress.py
@@ -2,11 +2,10 @@ import pyarrow as pa
 import pyarrow.csv as pa_csv
 from rich.console import Console
 from rich.progress import (
-  Progress, ProgressColumn, SpinnerColumn, TextColumn,
-  BarColumn, MofNCompleteColumn, TaskProgressColumn,
+  Progress, SpinnerColumn, TextColumn,
+  BarColumn, TaskProgressColumn,
   TimeRemainingColumn, TimeElapsedColumn,
 )
-from rich.progress_bar import ProgressBar
 from rich.table import Table
 
 from isaura.utils import rss_mb
@@ -60,86 +59,49 @@ class StreamingCsvSink:
     self.write_table(pa.Table.from_pandas(df, preserve_index=False))
 
 
-class _PulseBarColumn(ProgressColumn):
-  """Rich progress column that renders a pulsing bar while a task is in progress.
-
-  Switches to a solid filled bar when the task is complete.
-  """
-
-  def __init__(
-    self, bar_width=40,
-    style="rgb(36,26,58)",
-    complete_style="bold rgb(56,189,248)",
-    finished_style="bold rgb(34,197,94)",
-    pulse_style="bold rgb(244,114,182)",
-  ):
-    super().__init__()
-    self.bar_width = int(bar_width)
-    self.style = style
-    self.complete_style = complete_style
-    self.finished_style = finished_style
-    self.pulse_style = pulse_style
-
-  def render(self, task):
-    return ProgressBar(
-      total=task.total, completed=task.completed,
-      width=max(1, self.bar_width), pulse=not task.finished,
-      animation_time=task.get_time(),
-      style=self.style, complete_style=self.complete_style,
-      finished_style=self.finished_style, pulse_style=self.pulse_style,
-    )
-
-
 class ReadProgress:
   """Context manager that displays a live Rich progress bar during a read operation.
 
-  Shows files scanned, rows emitted, pending inputs, memory usage, and
-  elapsed/remaining time. Designed to be used with the `with` statement and
-  updated incrementally via update().
+  Shows files processed, row count, and elapsed/remaining time.
+  Designed to be used with the `with` statement and updated incrementally via update().
 
   Args:
       total_inputs: Total number of molecule inputs being queried (used to size the bar).
       console: Rich Console to render to. Defaults to a new stderr console.
+      description: Label shown next to the progress bar.
   """
 
-  def __init__(self, total_inputs=None, console=None):
+  def __init__(self, total_inputs=None, console=None, description="Reading"):
     self.total_inputs = total_inputs
     self.console = console or Console(force_terminal=True, stderr=True)
+    self.description = description
     self.progress = None
     self.task_id = None
+    self.found_rows = 0
     self.files_done = 0
     self.files_total = 0
-    self.found_rows = 0
     self.emitted_rows = 0
     self.unresolved = total_inputs or 0
-    self._tick = 0
-    self._phrases = ["scanning", "matching", "streaming", "finalizing"]
 
   def __enter__(self):
+    total = self.total_inputs
     self.progress = Progress(
-      SpinnerColumn(spinner_name="aesthetic"),
-      TextColumn("[bold magenta]{task.fields[phase]}[/]"),
-      _PulseBarColumn(bar_width=28, style="rgb(40,28,58)",
-        complete_style="bold rgb(56,189,248)",
-        finished_style="bold rgb(34,197,94)",
-        pulse_style="bold rgb(244,114,182)"),
+      SpinnerColumn(),
+      TextColumn("[progress.description]{task.description}"),
+      BarColumn(),
       TaskProgressColumn(text_format="[bold bright_cyan]{task.percentage:>3.0f}%[/]"),
-      MofNCompleteColumn(),
+      TextColumn("{task.completed}/{task.total}"),
       TextColumn("[cyan]files[/] {task.fields[files_done]}/{task.fields[files_total]}"),
-      TextColumn("[green]emitted[/] {task.fields[emitted_rows]}"),
-      TextColumn("[yellow]pending[/] {task.fields[unresolved]}"),
-      TextColumn("[magenta]rss[/] {task.fields[rss]}MB"),
-      TimeElapsedColumn(), TimeRemainingColumn(),
+      TimeElapsedColumn(),
+      TimeRemainingColumn(),
       console=self.console, transient=False,
       redirect_stdout=False, redirect_stderr=False,
       refresh_per_second=10, expand=True,
     )
     self.progress.__enter__()
-    total = self.total_inputs if self.total_inputs is not None else 100
     self.task_id = self.progress.add_task(
-      self._render("starting"), total=total, completed=0,
-      phase=self._render_phase("starting"), files_done=0, files_total=0,
-      emitted_rows=0, unresolved=self.unresolved, rss=f"{rss_mb():.0f}",
+      self.description, total=total, completed=0,
+      files_done=0, files_total=0,
     )
     return self
 
@@ -147,39 +109,27 @@ class ReadProgress:
     if self.progress is not None:
       self.progress.__exit__(et, ev, tb)
 
-  def _render(self, stage):
-    phrase = self._phrases[self._tick % len(self._phrases)]
-    return f"{phrase} {stage}"
-
-  def _render_phase(self, stage):
-    return self._render(stage).replace("_", " ")
-
   def update(self, stage=None, files_done=None, files_total=None,
              found_rows=None, emitted_rows=None, unresolved=None):
     """Update the progress bar with the latest scan state."""
+    if found_rows is not None:
+      self.found_rows = found_rows
     if files_done is not None:
       self.files_done = files_done
     if files_total is not None:
       self.files_total = files_total
-    if found_rows is not None:
-      self.found_rows = found_rows
     if emitted_rows is not None:
       self.emitted_rows = emitted_rows
     if unresolved is not None:
       self.unresolved = unresolved
-    self._tick += 1
     if self.progress is not None and self.task_id is not None:
       completed = self.found_rows
       total = self.total_inputs if self.total_inputs is not None else max(100, completed or 0)
       if completed > total:
         total = completed
       self.progress.update(
-        self.task_id, description=self._render(stage or "working"),
-        total=total, completed=completed,
-        phase=self._render_phase(stage or "working"),
+        self.task_id, completed=completed, total=total,
         files_done=self.files_done, files_total=self.files_total,
-        emitted_rows=self.emitted_rows, unresolved=self.unresolved,
-        rss=f"{rss_mb():.0f}",
       )
 
 

--- a/isaura/progress.py
+++ b/isaura/progress.py
@@ -44,7 +44,7 @@ class StreamingCsvSink:
     """Append a PyArrow Table to the CSV, writing the header only on the first call."""
     if table is None or table.num_rows == 0:
       return
-    opts = pa_csv.WriteOptions(include_header=not self._header_written)
+    opts = pa_csv.WriteOptions(include_header=not self._header_written, quoting_style="none", quoting_header="none")
     pa_csv.write_csv(table, self._fp, write_options=opts)
     self.rows_written += table.num_rows
     self._header_written = True

--- a/isaura/query.py
+++ b/isaura/query.py
@@ -85,7 +85,7 @@ def query_batched(
   wanted_list = list(wanted)
   src, src_desc = _src_expr(file_glob)
 
-  logger.info(
+  logger.debug(
     f"[query_batched] inputs={len(wanted_list)} "
     f"batch_size={batch_size} mem={mem_lim}GB threads={threads} src={src_desc}"
   )
@@ -127,7 +127,7 @@ def query_batched(
     conn.unregister("__wanted_inputs")
 
   dt = time.perf_counter() - t0
-  logger.info(f"[query_batched] done rows={total_rows} batches={n_batches} elapsed={dt:.2f}s rss={rss_mb():.0f}MB")
+  logger.debug(f"[query_batched] done rows={total_rows} batches={n_batches} elapsed={dt:.2f}s rss={rss_mb():.0f}MB")
 
 
 def chunked_query_batched(

--- a/isaura/stream.py
+++ b/isaura/stream.py
@@ -89,7 +89,7 @@ def stream_parquet_filtered(
       )
     )
 
-    logger.info(f"[stream] starting: {len(keys)} files, {remaining} wanted, batch_size={batch_size}")
+    logger.debug(f"[stream] starting: {len(keys)} files, {remaining} wanted, batch_size={batch_size}")
     if progress is not None:
       progress.update(
         stage="starting",
@@ -194,7 +194,7 @@ def stream_parquet_filtered(
               del chunk
             del filtered
 
-        logger.info(
+        logger.debug(
           f"[stream] file {ki + 1}/{len(keys)} done key={key.split('/')[-1]} "
           f"yielded={total_rows_yielded} remaining={remaining} rss={rss_mb():.0f}MB"
         )
@@ -209,7 +209,7 @@ def stream_parquet_filtered(
         except Exception:
           pass
   finally:
-    logger.info(
+    logger.debug(
       f"[stream] finished: files={len(keys)} yielded={total_rows_yielded} "
       f"chunks={n_chunks_yielded} remaining={remaining} rss={rss_mb():.0f}MB"
     )

--- a/isaura/stream.py
+++ b/isaura/stream.py
@@ -5,7 +5,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 
-from isaura.const import STREAM_DENSE_BATCH_ROWS, STREAM_DENSE_FILE_RATIO
+from isaura.const import INPUT_C, STREAM_DENSE_BATCH_ROWS, STREAM_DENSE_FILE_RATIO
 from isaura.logging import logger
 from isaura.utils import cleanup_temp_dir, make_temp, rss_mb
 
@@ -123,13 +123,16 @@ def stream_parquet_filtered(
           bool(dense_file_ratio) and n_rows > 0 and remaining >= max(1, int(n_rows * dense_file_ratio))
         )
 
+        schema_names = set(pf.schema_arrow.names)
+        parquet_col = next((c for c in [header] + INPUT_C if c in schema_names), header)
+
         if use_dense:
           dense_batch_rows = max(batch_size, STREAM_DENSE_BATCH_ROWS)
           for batch in pf.iter_batches(batch_size=dense_batch_rows):
             if remaining <= 0:
               break
             table = pa.Table.from_batches([batch])
-            mask = pc.is_in(table.column(header), wanted_arr)
+            mask = pc.is_in(table.column(parquet_col), wanted_arr)
             if pc.any(mask).as_py() is not True:
               continue
             filtered = table.filter(mask)
@@ -137,6 +140,8 @@ def stream_parquet_filtered(
               continue
             for start in range(0, filtered.num_rows, batch_size):
               chunk = filtered.slice(start, batch_size).to_pandas(split_blocks=True, self_destruct=True)
+              if parquet_col != header:
+                chunk = chunk.rename(columns={parquet_col: header})
               matched = set(chunk[header].astype(str).str.strip())
               remaining -= len(matched & wanted_set)
               wanted_set -= matched
@@ -157,7 +162,7 @@ def stream_parquet_filtered(
           for rg_idx in range(n_rg):
             if remaining <= 0:
               break
-            key_col = pf.read_row_group(rg_idx, columns=[header]).column(header)
+            key_col = pf.read_row_group(rg_idx, columns=[parquet_col]).column(parquet_col)
             mask = pc.is_in(key_col, wanted_arr)
             if pc.any(mask).as_py() is not True:
               del key_col, mask
@@ -169,6 +174,8 @@ def stream_parquet_filtered(
               continue
             for start in range(0, filtered.num_rows, batch_size):
               chunk = filtered.slice(start, batch_size).to_pandas(split_blocks=True, self_destruct=True)
+              if parquet_col != header:
+                chunk = chunk.rename(columns={parquet_col: header})
               matched = set(chunk[header].astype(str).str.strip())
               remaining -= len(matched & wanted_set)
               wanted_set -= matched

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
   { name = "Miquel Duran Frigola", email = "miquel@ersilia.io" },
   { name = "Abel Legese Shibiru", email = "abel@ersilia.io" },
   { name = "Marina Miñarro Lleonar", email = "marina@ersilia.io"},
-  { name = Ersilia Open Source Initiative, email = "hello@ersilia.io}
+  { name = "Ersilia Open Source Initiative", email = "hello@ersilia.io"}
 ]
 dependencies = [
     "boto3>=1.40.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [project]
 name = "isaura"
-version = "2.1.29"
+version = "2.2.0"
 description = "A lake of precalculated properties of biomedical entities based on the Ersilia Model Hub"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
   { name = "Miquel Duran Frigola", email = "miquel@ersilia.io" },
   { name = "Abel Legese Shibiru", email = "abel@ersilia.io" },
-  { name = "Marina Miñarro Lleonar", email = "marina@ersilia.io"}
+  { name = "Marina Miñarro Lleonar", email = "marina@ersilia.io"},
+  { name = Ersilia Open Source Initiative, email = "hello@ersilia.io}
 ]
 dependencies = [
     "boto3>=1.40.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 authors = [
   { name = "Miquel Duran Frigola", email = "miquel@ersilia.io" },
   { name = "Abel Legese Shibiru", email = "abel@ersilia.io" },
+  { name = "Marina Miñarro Lleonar", email = "marina@ersilia.io"}
 ]
 dependencies = [
     "boto3>=1.40.35",
@@ -18,7 +19,7 @@ dependencies = [
     "pybloom-live>=4.0.0",
     "python-dotenv>=1.1.1",
     "pyyaml>=6.0.3",
-    "rdkit==2024.3.6",
+    "rdkit>=2024.3.6",
     "requests>=2.32.5",
     "rich>=14.1.0",
     "questionary>=2.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "rdkit==2024.3.6",
     "requests>=2.32.5",
     "rich>=14.1.0",
+    "questionary>=2.0.1",
     "rich-click>=1.8.9",
     "tqdm>=4.67.1",
 ]

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,6 +15,13 @@ def cli(*args):
   return r
 
 
+def cli_fails(*args):
+  """Run a CLI command and assert it exits with a non-zero code."""
+  r = subprocess.run(["isaura", *args], capture_output=True, text=True)
+  assert r.returncode != 0, f"Expected failure but command succeeded: isaura {' '.join(args)}"
+  return r
+
+
 def load_inputs(path):
   with open(path, newline="") as f:
     return {(row.get("input") or row.get("smiles", "")).strip() for row in csv.DictReader(f)} - {""}
@@ -29,7 +36,14 @@ def normalized(df):
   return df.sort_values(ic).reset_index(drop=True)
 
 
+def test_0_create_project(cfg, state):
+  cli("create", "-pn", cfg["src"], "--access", "public")
+  state["created"] = True
+
+
 def test_1_write(cfg, state):
+  if not state.get("created"):
+    pytest.skip("project creation did not pass")
   cli(
     "write",
     "-m",
@@ -38,8 +52,6 @@ def test_1_write(cfg, state):
     cfg["version"],
     "-pn",
     cfg["src"],
-    "--access",
-    "public",
     "-i",
     cfg["input"],
   )
@@ -86,36 +98,36 @@ def test_4_inspect(cfg, state):
   if not state.get("wrote"):
     pytest.skip("write did not pass")
   out = tempfile.mktemp(suffix=".csv")
-  cli("inspect", "-m", cfg["model"], "-v", cfg["version"], "-pn", cfg["src"], "--access", "public", "-o", out)
+  cli(
+    "inspect",
+    "--model-id", cfg["model"],
+    "-v", cfg["version"],
+    "-pn", cfg["src"],
+    "-i", cfg["input"],
+    "-o", out,
+  )
   df = pd.read_csv(out)
   assert len(df) > 0, "inspect returned empty result"
 
 
-def test_5_copy(cfg, state):
+def test_5_persist(cfg, state):
   if not state.get("wrote"):
     pytest.skip("write did not pass")
-  cli("copy", "-m", cfg["model"], "-v", cfg["version"], "-pn", cfg["src"])
-  state["copied"] = True
+  cli("persist", "-m", cfg["model"], "-v", cfg["version"], "-pn", cfg["src"])
+  state["persisted"] = True
 
 
-def test_6_move(cfg, state):
-  if not state.get("wrote"):
-    pytest.skip("write did not pass")
-  cli("move", "-m", cfg["model"], "-v", cfg["version"], "-pn", cfg["src"])
-  state["moved"] = True
+def test_6_destroy_model(cfg, state):
+  if not state.get("persisted"):
+    pytest.skip("persist did not pass")
+  cli("destroy", "-m", cfg["model"], "-v", cfg["version"], "-pn", PUB, "--yes")
 
 
-def test_7_remove_model(cfg, state):
-  if not (state.get("copied") or state.get("moved")):
-    pytest.skip("copy/move did not pass")
-  cli("remove", "-m", cfg["model"], "-v", cfg["version"], "-pn", PUB, "--yes")
+def test_7_destroy_project(cfg, state):
+  cli("destroy", "-pn", cfg["src"], "--yes")
 
 
-def test_8_remove_project(cfg, state):
-  cli("remove", "-pn", cfg["src"], "--yes")
-
-
-def test_9_stats_writes_model_sizes(monkeypatch, tmp_path):
+def test_8_stats_writes_model_sizes(monkeypatch, tmp_path):
   from isaura.cli import cli as isaura_cli
 
   class FakeInspect:
@@ -141,14 +153,16 @@ def test_9_stats_writes_model_sizes(monkeypatch, tmp_path):
     def parquet_columns(self, bucket, parquet_key):
       return ["input", "mol_weight"]
 
+  from isaura.base import MinioStore
   monkeypatch.setattr("isaura.manage.IsauraInspect", FakeInspect)
   monkeypatch.setattr("isaura.manage.fetch_schema_from_github", lambda mid: {"id": mid})
+  monkeypatch.setattr(MinioStore, "require_bucket", lambda self, b: None)
 
   out_dir = tmp_path / "stats"
   runner = CliRunner()
   result = runner.invoke(
     isaura_cli,
-    ["stats", "-pn", "isaura-test", "--access", "public", "-o", str(out_dir), "-d", "."],
+    ["stats", "-pn", "isaura-test", "-o", str(out_dir)],
   )
 
   assert result.exit_code == 0, result.output
@@ -158,3 +172,96 @@ def test_9_stats_writes_model_sizes(monkeypatch, tmp_path):
   assert data["models_total"] == 1
   assert data["models"][0]["total_bytes"] == 1073742336
   assert data["models"][0]["total_gb"] == 1.000000
+
+
+# ---------------------------------------------------------------------------
+# Negative tests
+# ---------------------------------------------------------------------------
+
+class TestWriteNegative:
+  def test_write_missing_model_id(self, cfg):
+    """write without --model-id must fail."""
+    cli_fails("write", "-pn", cfg["src"], "-v", cfg["version"], "-i", cfg["input"])
+
+  def test_write_missing_project_name(self, cfg):
+    """write without --project-name must fail."""
+    cli_fails("write", "-m", cfg["model"], "-v", cfg["version"], "-i", cfg["input"])
+
+  def test_write_missing_input(self, cfg):
+    """write without --input must fail."""
+    cli_fails("write", "-m", cfg["model"], "-v", cfg["version"], "-pn", cfg["src"])
+
+  def test_write_model_filename_mismatch(self, cfg, tmp_path):
+    """write where filename contains a different model ID must fail."""
+    wrong = tmp_path / "eos9999_output.csv"
+    wrong.write_text("input,value\nCCO,1.0\n")
+    cli_fails("write", "-m", cfg["model"], "-v", cfg["version"], "-pn", cfg["src"], "-i", str(wrong))
+
+
+class TestReadNegative:
+  def test_read_missing_model_id(self, cfg):
+    """read without --model-id must fail."""
+    cli_fails("read", "-pn", cfg["src"], "-i", cfg["input"])
+
+  def test_read_missing_project_name(self, cfg):
+    """read without --project-name must fail."""
+    cli_fails("read", "-m", cfg["model"], "-i", cfg["input"])
+
+  def test_read_missing_input(self, cfg):
+    """read without --input must fail."""
+    cli_fails("read", "-m", cfg["model"], "-pn", cfg["src"])
+
+  def test_read_model_filename_mismatch(self, cfg, tmp_path):
+    """read where output filename contains a different model ID must fail."""
+    out = tmp_path / "eos9999_output.csv"
+    cli_fails("read", "-m", cfg["model"], "-pn", cfg["src"], "-i", cfg["input"], "-o", str(out))
+
+
+class TestInspectNegative:
+  def test_inspect_missing_model_id(self, cfg):
+    """inspect without --model_id must fail."""
+    cli_fails("inspect", "-v", cfg["version"], "--access", "public", "-i", cfg["input"], "-o", "out.csv")
+
+  def test_inspect_missing_input(self, cfg):
+    """inspect without --input must fail."""
+    cli_fails("inspect", "--model_id", cfg["model"], "-v", cfg["version"], "--access", "public", "-o", "out.csv")
+
+  def test_inspect_missing_output(self, cfg):
+    """inspect without --output must fail."""
+    cli_fails("inspect", "--model_id", cfg["model"], "-v", cfg["version"], "--access", "public", "-i", cfg["input"])
+
+  def test_inspect_missing_access(self, cfg):
+    """inspect without --access (and no --project-name) must fail."""
+    cli_fails("inspect", "--model_id", cfg["model"], "-v", cfg["version"], "-i", cfg["input"], "-o", "out.csv")
+
+
+class TestDestroyNegative:
+  def test_destroy_model_without_version(self, cfg):
+    """destroy with --model-id but without --version must fail."""
+    cli_fails("destroy", "-pn", cfg["src"], "-m", cfg["model"], "--yes")
+
+  def test_destroy_reserved_bucket_without_model(self):
+    """destroy of a canonical bucket without specifying a model must fail."""
+    cli_fails("destroy", "-pn", "isaura-public", "--yes")
+
+  def test_destroy_missing_project_name(self, cfg):
+    """destroy without --project-name must fail."""
+    cli_fails("destroy", "-m", cfg["model"], "-v", cfg["version"], "--yes")
+
+
+class TestCatalogNegative:
+  def test_catalog_missing_project_name(self):
+    """catalog without --project-name must print an error and exit cleanly (rc=0 with message)."""
+    r = subprocess.run(["isaura", "catalog"], capture_output=True, text=True)
+    combined = r.stdout + r.stderr
+    assert "project" in combined.lower(), "Expected a helpful message about missing project name"
+
+
+class TestStatsNegative:
+  def test_stats_missing_project_name(self, tmp_path):
+    """stats without --project-name must fail."""
+    cli_fails("stats", "-o", str(tmp_path))
+
+  def test_stats_missing_output_dir(self, cfg):
+    """stats without --output-dir must fail."""
+    cli_fails("stats", "-pn", cfg["src"])


### PR DESCRIPTION
## Summary
This PR is a comprehensive overhaul of the isaura CLI focused on usability, consistency, and cleaner user feedback. No breaking changes to the Python API.

### Command changes

- write: removed --access flag — access level is now read automatically from the project bucket's metadata. Added model ID / filename consistency check (errors if the filename contains a different model ID than --model-id).
- read: --project-name is now required. --version auto-resolves to the latest stored version when omitted. --output-file renamed to --output. Same model/filename mismatch check as write. Approximate search (--approximate) disabled in CLI (still available in Python API).
- pull: --version auto-resolves to latest stored version in the remote bucket when omitted. Progress display overhauled — three explicit phases with spinners (loading inputs → checking index → storing locally), replacing a wall of loguru timestamps.
- inspect: --input and --output both required. The list-all-inputs mode (no input file) has been removed.
- stats: --access flag removed — pass isaura-public, isaura-private, or a custom project name directly to --project-name.
- catalog: project name required (friendly error with guidance). Auth check before attempting remote connection.
- copy → persist: renamed to better reflect what it does (routes data from a staging project into the canonical buckets).
- destroy: --version now required when --model-id is set, so deletions are scoped to a specific model version rather than all versions. Reserved canonical buckets (isaura-public/isaura-private) can no longer be fully destroyed — only individual model versions inside them.
- info: now shows an access type column (public in green, private in red) for each project.
- create: new command to explicitly create a project bucket with an access level before writing to it.

### Approximate search / NNS deprecated

- The Milvus vector database and NNS (nearest-neighbour search) API containers have been removed from docker-compose.yml (commented out with instructions to re-enable if needed). isaura engine --start now only starts MinIO.

Consequences:

- --approximate / -nn flag removed from the isaura read CLI command
- Approximate search is still available in the Python API (IsauraReader(approximate=True)) but will fail gracefully if the NNS service is not running
- All NNS-related log output (previously ERROR-level when the service was unreachable) has been demoted to DEBUG

### Progress bars & logging

- Read and pull progress bars now match the write command style (spinner + filling bar + percentage + time remaining). The old pulsing animated bar is gone.
- Write progress bar now shows percentage and time remaining (previously indeterminate for CSV inputs because total rows weren't counted upfront).
- Per-file stream logs (file 10/136 done...) demoted from INFO to DEBUG — no longer flood the terminal during read/pull.

NNS/Milvus errors demoted to DEBUG (service is optional; errors were always non-fatal but looked alarming).
### Tests

- Updated test_workflow.py to reflect all CLI changes: persist replaces copy, destroy replaces remove, create added as setup step, --access removed from write/stats.
- Added 16 negative tests covering missing required flags and input validation (model ID mismatch, missing --version on destroy, reserved bucket protection, etc.).

### Docs

- README.md updated: Python API section removed, CLI section fully rewritten to reflect all command changes.
- docs/API_AND_CLI_USAGE.md, HOW_IT_WORKS.md, CONFIGURATION.md, TROUBLESHOOTING.md all updated.
